### PR TITLE
🎨 Palette: Add "Reset to Defaults" functionality to timer settings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-10-31 - [Accessibility for Icon-only Buttons and Inputs]
 **Learning:** Icon-only buttons and inputs within a HIIT timer app often rely on visual cues (icons) that are not accessible to screen reader users. Adding `aria-label` provides the necessary context without altering the visual design.
 **Action:** Always check for `aria-label` or `title` on buttons that do not contain visible text and on inputs that rely on icon-based labels.
+
+## 2024-11-20 - [Reset to Defaults UX Pattern]
+**Learning:** Providing a "Reset to Defaults" option in configuration-heavy interfaces (like workout timers) is a high-value micro-UX improvement. It gives users a "safe way back" when they've over-customized settings.
+**Action:** Look for opportunities to add reset-to-default functionality in complex configuration views, ensuring it's accessible and requires confirmation.

--- a/src/components/SettingsTimerConfig.astro
+++ b/src/components/SettingsTimerConfig.astro
@@ -1,13 +1,14 @@
 ---
-import ExerciseRestIcon from '@components/ExerciseRestIcon.astro'
-import PrepareIcon from '@components/PrepareIcon.astro'
-import TimerIcon from '@components/TimerIcon.astro'
-import ExerciseWork from '@components/ExerciseWork.astro'
-import RoundsIcon from '@components/RoundsIcon.astro'
-import Helper from '@components/Helper.astro'
+import ExerciseRestIcon from "@components/ExerciseRestIcon.astro";
+import PrepareIcon from "@components/PrepareIcon.astro";
+import TimerIcon from "@components/TimerIcon.astro";
+import ExerciseWork from "@components/ExerciseWork.astro";
+import RoundsIcon from "@components/RoundsIcon.astro";
+import Helper from "@components/Helper.astro";
+import RestoreIcon from "@components/RestoreIcon.astro";
 
-const { vertical = false } = Astro.props
-const className = vertical ? 'vertical' : 'horizontal'
+const { vertical = false } = Astro.props;
+const className = vertical ? "vertical" : "horizontal";
 ---
 
 <section id="settings-timers">
@@ -20,6 +21,13 @@ const className = vertical ? 'vertical' : 'horizontal'
       <RoundsIcon />
       <span class="total-routine-exercises"></span>
     </div>
+    <button
+      id="reset-settings"
+      title="Reset to default settings"
+      aria-label="Reset to default settings"
+    >
+      <RestoreIcon />
+    </button>
   </header>
   <div class={className}>
     <div id="prepContainer">
@@ -88,59 +96,67 @@ const className = vertical ? 'vertical' : 'horizontal'
 </section>
 
 <script>
-  import { getSettings, updateSettings } from '../assets/main'
-  import { updateTotalWorkouts, updateRoutineStats } from '../assets/settings'
-  const { prepDuration, workDuration, restDuration, rounds } = getSettings()
+  import { getSettings, updateSettings } from "../assets/main";
+  import { defaultSettings } from "../assets/defaultSettings";
+  import { updateTotalWorkouts, updateRoutineStats } from "../assets/settings";
+  const { prepDuration, workDuration, restDuration, rounds } = getSettings();
 
   function Init() {
     const prepDurationInput = document.getElementById(
-      'prepDuration'
-    ) as HTMLInputElement | null
+      "prepDuration",
+    ) as HTMLInputElement | null;
     const workoutDurationInput = document.getElementById(
-      'workDuration'
-    ) as HTMLInputElement | null
+      "workDuration",
+    ) as HTMLInputElement | null;
     const restDurationInput = document.getElementById(
-      'restDuration'
-    ) as HTMLInputElement | null
+      "restDuration",
+    ) as HTMLInputElement | null;
     const roundsInput = document.getElementById(
-      'rounds'
-    ) as HTMLInputElement | null
+      "rounds",
+    ) as HTMLInputElement | null;
 
     // Set the values
-    updateRoutineStats()
-    updateTotalWorkouts()
-    if (prepDurationInput) prepDurationInput.value = prepDuration.toString()
+    updateRoutineStats();
+    updateTotalWorkouts();
+    if (prepDurationInput) prepDurationInput.value = prepDuration.toString();
     if (workoutDurationInput)
-      workoutDurationInput.value = workDuration.toString()
-    if (restDurationInput) restDurationInput.value = restDuration.toString()
-    if (roundsInput) roundsInput.value = `${rounds}`
+      workoutDurationInput.value = workDuration.toString();
+    if (restDurationInput) restDurationInput.value = restDuration.toString();
+    if (roundsInput) roundsInput.value = `${rounds}`;
 
     // Save the settings
-    prepDurationInput?.addEventListener('change', e => {
-      const value = parseInt((e.target as HTMLInputElement).value)
-      updateSettings({ ...getSettings(), prepDuration: +value })
-    })
+    prepDurationInput?.addEventListener("change", (e) => {
+      const value = parseInt((e.target as HTMLInputElement).value);
+      updateSettings({ ...getSettings(), prepDuration: +value });
+    });
 
-    workoutDurationInput?.addEventListener('change', e => {
-      const value = parseInt((e.target as HTMLInputElement).value)
-      updateSettings({ ...getSettings(), workDuration: +value })
-      updateRoutineStats()
-    })
+    workoutDurationInput?.addEventListener("change", (e) => {
+      const value = parseInt((e.target as HTMLInputElement).value);
+      updateSettings({ ...getSettings(), workDuration: +value });
+      updateRoutineStats();
+    });
 
-    restDurationInput?.addEventListener('change', e => {
-      const value = parseInt((e.target as HTMLInputElement).value)
-      updateSettings({ ...getSettings(), restDuration: +value })
-      updateRoutineStats()
-    })
+    restDurationInput?.addEventListener("change", (e) => {
+      const value = parseInt((e.target as HTMLInputElement).value);
+      updateSettings({ ...getSettings(), restDuration: +value });
+      updateRoutineStats();
+    });
 
-    roundsInput?.addEventListener('change', e => {
-      const value = parseInt((e.target as HTMLInputElement).value)
-      updateSettings({ ...getSettings(), rounds: +value })
-      updateRoutineStats()
-    })
+    roundsInput?.addEventListener("change", (e) => {
+      const value = parseInt((e.target as HTMLInputElement).value);
+      updateSettings({ ...getSettings(), rounds: +value });
+      updateRoutineStats();
+    });
+
+    document.getElementById("reset-settings")?.addEventListener("click", () => {
+      if (confirm("Are you sure you want to reset all settings to default?")) {
+        updateSettings(defaultSettings);
+        window.location.reload();
+      }
+    });
   }
 
-  document.addEventListener('DOMContentLoaded', Init)
+  document.addEventListener("DOMContentLoaded", Init);
 </script>
 
 <style>
@@ -166,6 +182,23 @@ const className = vertical ? 'vertical' : 'horizontal'
         & svg {
           font-size: 60%;
           opacity: 0.6;
+        }
+      }
+
+      & button {
+        padding: 0;
+        border: 0;
+        background: transparent;
+        width: auto;
+        margin: 0;
+        box-shadow: none;
+        font-size: 60%;
+        opacity: 0.6;
+        cursor: pointer;
+        color: inherit;
+
+        &:hover {
+          opacity: 1;
         }
       }
     }


### PR DESCRIPTION
### 💡 What
Added a "Reset to Defaults" feature to the timer settings. Users can now quickly revert all workout intervals and rounds to their original factory settings.

### 🎯 Why
In a highly customizable workout app like this, users might over-configure their timers and find it tedious to manually reset each value. A one-click reset provides a convenient way to start fresh.

### ♿ Accessibility
- The new reset button is a semantic `<button>` element.
- It includes both `aria-label` and `title` attributes for screen readers and tooltips.
- The button is fully keyboard-accessible and part of the natural tab order.

### ✅ Verification
- Manually verified on a local development server.
- Used a Playwright script to automate the verification of the reset logic and UI.
- Ran `pnpm build` to ensure the project lints and builds correctly.
- Cleaned up local development artifacts before submission.

---
*PR created automatically by Jules for task [13995108940895992620](https://jules.google.com/task/13995108940895992620) started by @galiprandi*