### PR TITLE
Improve sound management and persistence

### DIFF
--- a/src/assets/audio.ts
+++ b/src/assets/audio.ts
@@ -3,21 +3,22 @@ const audioKey = "audioEnable";
 
 document.addEventListener("DOMContentLoaded", () => {
   player = document.getElementById("player") as HTMLAudioElement | null;
-  if (!player) setAudioDisable();
-  else if (getAudioStatus()) player.muted = false;
+  if (player) {
+    player.muted = !getAudioStatus();
+  }
 });
 
 // Set audio disable
 export const setAudioDisable = () => {
   if (player) player.muted = true;
-  localStorage.removeItem(audioKey);
+  localStorage.setItem(audioKey, "false");
 };
 
 // Set audio enable
 export const setAudioEnable = () => {
   if (player) player.muted = false;
-  play("tap", true);
   localStorage.setItem(audioKey, "true");
+  play("tap", true);
 };
 
 // Set audio status
@@ -27,7 +28,7 @@ export const setAudioStatus = (status: boolean) => {
 };
 
 // Get audio status
-export const getAudioStatus = () => !!localStorage.getItem(audioKey);
+export const getAudioStatus = () => localStorage.getItem(audioKey) !== "false";
 
 // Play sound function
 export const play = async (src: Sound, force = false) => {
@@ -40,7 +41,6 @@ export const play = async (src: Sound, force = false) => {
     await player.play();
   } catch (error) {
     console.error(error);
-    setAudioDisable();
   }
 };
 


### PR DESCRIPTION
Improved the sound management by making it enabled by default and ensuring that user preferences are persisted correctly in localStorage. Fixed a bug where browser autoplay restrictions would lead to the audio being permanently disabled in the application settings. Added logic to synchronize the audio player's muted state with the stored preference upon initialization.

---
*PR created automatically by Jules for task [11399360295700139417](https://jules.google.com/task/11399360295700139417) started by @galiprandi*