### PR TITLE
🎨 Palette: Add empty state to routine list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,7 +1,14 @@
 ## 2024-10-31 - [Accessibility for Icon-only Buttons and Inputs]
+
 **Learning:** Icon-only buttons and inputs within a HIIT timer app often rely on visual cues (icons) that are not accessible to screen reader users. Adding `aria-label` provides the necessary context without altering the visual design.
 **Action:** Always check for `aria-label` or `title` on buttons that do not contain visible text and on inputs that rely on icon-based labels.
 
 ## 2024-11-20 - [Reset to Defaults UX Pattern]
+
 **Learning:** Providing a "Reset to Defaults" option in configuration-heavy interfaces (like workout timers) is a high-value micro-UX improvement. It gives users a "safe way back" when they've over-customized settings.
 **Action:** Look for opportunities to add reset-to-default functionality in complex configuration views, ensuring it's accessible and requires confirmation.
+
+## 2025-01-24 - [Empty State UX Pattern]
+
+**Learning:** Providing a clear "empty state" when a list (like exercises) is empty prevents user confusion and provides a direct path to action. A good empty state includes a helpful message and a prominent "Add" button.
+**Action:** Always implement an empty state for dynamic lists to guide the user when no data is present.

--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -87,6 +87,14 @@ export const dictionary = {
     en: "Train",
     es: "Entrenar",
   },
+  "No exercises added yet. Start your routine!": {
+    en: "No exercises added yet. Start your routine!",
+    es: "Aún no hay ejercicios agregados. ¡Comienza tu rutina!",
+  },
+  "Add Exercise": {
+    en: "Add Exercise",
+    es: "Agregar Ejercicio",
+  },
 };
 
 const langs: AvailableLanguages[] = ["en", "es"];

--- a/src/components/SettingsRoutineList.astro
+++ b/src/components/SettingsRoutineList.astro
@@ -24,6 +24,16 @@ import UpIcon from "./UpIcon.astro";
     >
   </section>
 
+  <div id="empty-routine-state" style="display: none;">
+    <p data-i18n="No exercises added yet. Start your routine!">
+      No exercises added yet. Start your routine!
+    </p>
+    <button id="add-first-item" class="secondary">
+      <Plus />
+      <span data-i18n="Add Exercise">Add Exercise</span>
+    </button>
+  </div>
+
   <dialog id="add-edit-modal">
     <article>
       <header>
@@ -121,10 +131,25 @@ import UpIcon from "./UpIcon.astro";
 
       const { workouts } = getSettings();
       const workoutsList = document.getElementById("workouts-list");
+      const emptyState = document.getElementById("empty-routine-state");
+      const buttonsSection = document.querySelector("#routine-list > .buttons");
       const template = document.getElementById(
         "workout-item-template",
       ) as HTMLTemplateElement;
+
       if (!workoutsList || !template) return;
+
+      if (workouts.length === 0) {
+        if (emptyState) emptyState.style.display = "block";
+        if (workoutsList) workoutsList.style.display = "none";
+        if (buttonsSection)
+          (buttonsSection as HTMLElement).style.display = "none";
+      } else {
+        if (emptyState) emptyState.style.display = "none";
+        if (workoutsList) workoutsList.style.display = "block";
+        if (buttonsSection)
+          (buttonsSection as HTMLElement).style.display = "flex";
+      }
 
       updateTextContent("#workouts-list", "");
       const { speechOnTap } = await import("../assets/domHelpers");
@@ -163,14 +188,23 @@ import UpIcon from "./UpIcon.astro";
       speechOnTap();
     };
 
-    const init = () => {
-      updateRoutineList();
+    const init = async () => {
+      const { initTranslation } = await import("../assets/dictionary");
+      initTranslation();
+      await updateRoutineList();
 
       if (!inputAddEditItems) throw new Error("Input not found");
       if (!modalAddOrEdit) throw new Error("Modal not found");
       if (!formAddEditItems) throw new Error("Form not found");
 
       onClick("#add-new-item", () => {
+        if (!formAddEditItems) return;
+        formAddEditItems.dataset.idx = "";
+        inputAddEditItems.value = "";
+        modalAddOrEdit.showModal();
+      });
+
+      onClick("#add-first-item", () => {
         if (!formAddEditItems) return;
         formAddEditItems.dataset.idx = "";
         inputAddEditItems.value = "";
@@ -215,7 +249,7 @@ import UpIcon from "./UpIcon.astro";
       modalAddOrEdit.close();
     };
 
-    document.addEventListener("DOMContentLoaded", init);
+    document.addEventListener("DOMContentLoaded", async () => await init());
   </script>
 
   <style>
@@ -262,6 +296,19 @@ import UpIcon from "./UpIcon.astro";
 
       .delete {
         color: red;
+      }
+    }
+
+    #empty-routine-state {
+      text-align: center;
+      padding: 2em;
+      border: 2px dashed rgba(255, 255, 255, 0.2);
+      border-radius: 8px;
+      margin: 1em 0;
+
+      & p {
+        margin-bottom: 1.5em;
+        opacity: 0.8;
       }
     }
   </style>


### PR DESCRIPTION
I implemented an empty state for the exercise routine list in the settings page. This improves the UX by providing clear guidance and a direct call-to-action when the list is empty, instead of showing a blank space.

Highlights:
- 💡 **What**: New empty state UI with a message and "Add Exercise" button.
- 🎯 **Why**: Helps new users understand how to start building their routine.
- ♿ **Accessibility**: Uses semantic buttons and handles translations.
- 🌍 **Internationalization**: Added English and Spanish translations.

---
*PR created automatically by Jules for task [12527500245010473092](https://jules.google.com/task/12527500245010473092) started by @galiprandi*