### PR TITLE
🎨 Palette: Fix audio toggle labels and localize global ARIA attributes

### DIFF
--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -183,6 +183,34 @@ export const dictionary = {
     en: "Exercise?",
     es: "¿Ejercicio?",
   },
+  "Turn audio off": {
+    en: "Turn audio off",
+    es: "Desactivar sonido",
+  },
+  "Turn audio on": {
+    en: "Turn audio on",
+    es: "Activar sonido",
+  },
+  "Reset to default settings": {
+    en: "Reset to default settings",
+    es: "Restablecer ajustes predeterminados",
+  },
+  "Open help": {
+    en: "Open help",
+    es: "Abrir ayuda",
+  },
+  Close: {
+    en: "Close",
+    es: "Cerrar",
+  },
+  "Share this app": {
+    en: "Share this app",
+    es: "Compartir esta app",
+  },
+  "Configure routine": {
+    en: "Configure routine",
+    es: "Configurar rutina",
+  },
 };
 
 const langs: AvailableLanguages[] = ["en", "es"];

--- a/src/components/AudioControl.astro
+++ b/src/components/AudioControl.astro
@@ -4,10 +4,18 @@ import AudioOffIcon from './AudioOffIcon.astro'
 ---
 
 <div id="enable-audio">
-  <button id="btn-on" aria-label="Turn audio on" title="Turn audio on">
+  <button
+    id="btn-on"
+    data-i18n-aria-label="Turn audio off"
+    data-i18n-title="Turn audio off"
+  >
     <AudioOnIcon />
   </button>
-  <button id="btn-off" aria-label="Turn audio off" title="Turn audio off">
+  <button
+    id="btn-off"
+    data-i18n-aria-label="Turn audio on"
+    data-i18n-title="Turn audio on"
+  >
     <AudioOffIcon />
   </button>
   <audio id="player">
@@ -42,6 +50,9 @@ import AudioOffIcon from './AudioOffIcon.astro'
     setAudioEnable,
     setAudioDisable,
   } from '../assets/audio'
+  import { initTranslation } from '../assets/dictionary'
+
+  const container = document.getElementById('enable-audio')
   const btnOn = document.getElementById('btn-on') as HTMLButtonElement | null
   const btnOff = document.getElementById('btn-off') as HTMLButtonElement | null
 
@@ -64,6 +75,8 @@ import AudioOffIcon from './AudioOffIcon.astro'
       btnOn.style.display = 'none'
       btnOff.style.display = 'block'
     }
+
+    if (container) initTranslation(container)
   }
 
   document.addEventListener('DOMContentLoaded', async () => {

--- a/src/components/GoToHome.astro
+++ b/src/components/GoToHome.astro
@@ -4,8 +4,8 @@ import Home from '@icons/Home.icon.astro'
 
 <button
   class="btn-go-home icon contrast outline"
-  title="Return to home"
-  aria-label="Return to home"><Home /></button
+  data-i18n-title="Return to home"
+  data-i18n-aria-label="Return to home"><Home /></button
 >
 
 <script>

--- a/src/components/GoToSettings.astro
+++ b/src/components/GoToSettings.astro
@@ -5,8 +5,8 @@ import Config from './icons/Config.icon.astro'
 <button
   id="btn-routine-config"
   class="contrast outline icon"
-  title="Config Routine"
-  aria-label="Configure routine"
+  data-i18n-title="Config Routine"
+  data-i18n-aria-label="Configure routine"
   ><Config /></button
 >
 

--- a/src/components/GoToTrain.astro
+++ b/src/components/GoToTrain.astro
@@ -2,7 +2,10 @@
 import Continue from '@icons/Continue.icon.astro'
 ---
 
-<button class="go-to-train" title="Start Routine"
+<button
+  class="go-to-train"
+  data-i18n-title="Start Routine"
+  data-i18n-aria-label="Start Routine"
   ><Continue /><span data-i18n="Train">Train</span>
 </button>
 

--- a/src/components/Helper.astro
+++ b/src/components/Helper.astro
@@ -9,7 +9,7 @@ const { title, description } = Astro.props
   class="btn-open-dialog"
   data-title={title}
   data-description={description}
-  aria-label="Open help"
+  data-i18n-aria-label="Open help"
 >
   <HelpIcon />
 </button>
@@ -23,7 +23,12 @@ const { title, description } = Astro.props
       <p class="description"></p>
     </div>
     <footer>
-      <button id="btn-close-dialog" title="Close" class="contrast">Close</button>
+      <button
+        id="btn-close-dialog"
+        data-i18n-title="Close"
+        class="contrast"
+        data-i18n="Close">Close</button
+      >
     </footer>
   </article>
 </dialog>

--- a/src/components/SettingsTimerConfig.astro
+++ b/src/components/SettingsTimerConfig.astro
@@ -23,8 +23,8 @@ const className = vertical ? "vertical" : "horizontal";
     </div>
     <button
       id="reset-settings"
-      title="Reset to default settings"
-      aria-label="Reset to default settings"
+      data-i18n-title="Reset to default settings"
+      data-i18n-aria-label="Reset to default settings"
     >
       <RestoreIcon />
     </button>

--- a/src/components/ShareApp.astro
+++ b/src/components/ShareApp.astro
@@ -4,8 +4,8 @@ import CloseIcon from "./CloseIcon.astro";
 
 <button
   id="share_app"
-  title="Share this app with your friends!"
-  aria-label="Share this app"
+  data-i18n-title="Share this app with your friends!"
+  data-i18n-aria-label="Share this app"
 >
   <img
     id="qr_link"
@@ -17,11 +17,11 @@ import CloseIcon from "./CloseIcon.astro";
 </button>
 
 <dialog id="dialog">
-  <button id="dialog_close" aria-label="Close">
+  <button id="dialog_close" data-i18n-aria-label="Close">
     <CloseIcon />
   </button>
   <div>
-    <button id="btn_share_big" aria-label="Share this app">
+    <button id="btn_share_big" data-i18n-aria-label="Share this app">
       <img
         id="qr_link_big"
         src="/tabata/qr_link.svg"


### PR DESCRIPTION
I fixed the audio toggle button labels which were previously describing the current state instead of the resulting action. I also integrated the app's internationalization system into several global icon-only buttons (Help, Home, Settings, Train, Share, Reset) to ensure that ARIA labels and tooltips are localized for non-English users. Added missing keys to `src/assets/dictionary.ts` and updated components to use `data-i18n-*` attributes. verified with tests and Playwright.

---
*PR created automatically by Jules for task [2652203526288926637](https://jules.google.com/task/2652203526288926637) started by @galiprandi*