### PR TITLE
🎨 Palette: Improve AudioControl Accessibility and Layout

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 
 **Learning:** Providing a clear "empty state" when a list (like exercises) is empty prevents user confusion and provides a direct path to action. A good empty state includes a helpful message and a prominent "Add" button.
 **Action:** Always implement an empty state for dynamic lists to guide the user when no data is present.
+
+## 2026-06-22 - [Toggle Control Accessibility]
+**Learning:** ARIA labels for toggle controls (e.g., audio on/off) must describe the *action* taken upon interaction (e.g., "Turn audio off") rather than the current state of the system. This provides clear intent to screen reader users.
+**Action:** Always verify that toggle buttons have labels representing the transition, and use 'inline-flex' for icon button display to maintain design system alignment.

--- a/src/components/AudioControl.astro
+++ b/src/components/AudioControl.astro
@@ -6,19 +6,19 @@ import AudioOffIcon from "./AudioOffIcon.astro";
 <div id="enable-audio">
   <button
     id="btn-on"
-    data-i18n-aria-label="Turn audio on"
-    data-i18n-title="Turn audio on"
-    aria-label="Turn audio on"
-    title="Turn audio on"
+    data-i18n-aria-label="Turn audio off"
+    data-i18n-title="Turn audio off"
+    aria-label="Turn audio off"
+    title="Turn audio off"
   >
     <AudioOnIcon />
   </button>
   <button
     id="btn-off"
-    data-i18n-aria-label="Turn audio off"
-    data-i18n-title="Turn audio off"
-    aria-label="Turn audio off"
-    title="Turn audio off"
+    data-i18n-aria-label="Turn audio on"
+    data-i18n-title="Turn audio on"
+    aria-label="Turn audio on"
+    title="Turn audio on"
   >
     <AudioOffIcon />
   </button>
@@ -34,12 +34,12 @@ import AudioOffIcon from "./AudioOffIcon.astro";
     right: 0;
     padding: 0.8rem;
     cursor: pointer;
+    z-index: 1000;
   }
 
   button {
     font-size: 1.7em;
     color: white;
-    min-width: unset !important;
     background: none;
     border: 0;
     padding: 0;
@@ -70,11 +70,11 @@ import AudioOffIcon from "./AudioOffIcon.astro";
     const enable = getAudioStatus();
 
     if (enable) {
-      btnOn.style.display = "block";
+      btnOn.style.display = "inline-flex";
       btnOff.style.display = "none";
     } else {
       btnOn.style.display = "none";
-      btnOff.style.display = "block";
+      btnOff.style.display = "inline-flex";
     }
   };
 


### PR DESCRIPTION
I have implemented a micro-UX improvement focusing on accessibility and layout consistency in the `AudioControl` component.

### 💡 What
- **Label Correction**: Swapped `aria-label` and `title` attributes (and their localized counterparts) so they describe the *result* of the interaction (e.g., clicking the speaker icon now correctly says "Turn audio off" if sound is currently playing).
- **Layout Consistency**: Changed the display of active buttons from `block` to `inline-flex` to align with the global design system and ensure icons are perfectly centered within their touch targets.
- **Layering Fix**: Added `z-index: 1000` to the audio control container to ensure it remains visible and interactive above other UI elements.
- **Standardized Touch Targets**: Removed `min-width: unset` to allow buttons to inherit the standard 48x48px touch targets defined in the global layout.

### 🎯 Why
These changes solve several UX and accessibility issues:
1. **Screen Reader Clarity**: Screen reader users now hear the action they are about to perform, which is the standard accessibility pattern for toggle controls.
2. **Visual Alignment**: Using `inline-flex` prevents slight misalignments often caused by `block` display on icon buttons.
3. **Robustness**: High z-index prevents the control from becoming "buried" under other absolute or fixed elements.

### ♿ Accessibility
- Verified that ARIA labels accurately reflect the upcoming state change.
- Ensured minimum touch targets of 48x48px are respected for easier interaction while exercising.
- Maintained full keyboard navigation support.

### 📸 Verification
- Ran `pnpm test` and `pnpm build` to ensure no regressions.
- Used Playwright to capture screenshots of both audio states, verifying visibility and attribute correctness.

---
*PR created automatically by Jules for task [6573578550970321956](https://jules.google.com/task/6573578550970321956) started by @galiprandi*