### PR TITLE
🎨 Palette: Add duplicate exercise feature

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,5 +14,11 @@
 **Action:** Always implement an empty state for dynamic lists to guide the user when no data is present.
 
 ## 2026-06-22 - [Toggle Control Accessibility]
-**Learning:** ARIA labels for toggle controls (e.g., audio on/off) must describe the *action* taken upon interaction (e.g., "Turn audio off") rather than the current state of the system. This provides clear intent to screen reader users.
+
+**Learning:** ARIA labels for toggle controls (e.g., audio on/off) must describe the _action_ taken upon interaction (e.g., "Turn audio off") rather than the current state of the system. This provides clear intent to screen reader users.
 **Action:** Always verify that toggle buttons have labels representing the transition, and use 'inline-flex' for icon button display to maintain design system alignment.
+
+## 2025-05-15 - [Safe Action Dispatching in Shared Templates]
+
+**Learning:** When using shared templates with multiple action buttons, identifying buttons by simple substrings (e.g., `className.includes("up")`) is brittle and can lead to multiple actions being triggered if class names overlap (e.g., "up" matching "duplicate").
+**Action:** Use `element.classList.contains()` for exact class matching to ensure one button triggers exactly one intended action.

--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -139,6 +139,10 @@ export const dictionary = {
     en: "Delete exercise",
     es: "Eliminar ejercicio",
   },
+  "Duplicate exercise": {
+    en: "Duplicate exercise",
+    es: "Duplicar ejercicio",
+  },
   "Move exercise up": {
     en: "Move exercise up",
     es: "Mover ejercicio arriba",

--- a/src/assets/routine/RoutineService.test.ts
+++ b/src/assets/routine/RoutineService.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { RoutineService } from './RoutineService';
-import { RoutineStorageService } from './RoutineStorage';
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { RoutineService } from "./RoutineService";
+import { RoutineStorageService } from "./RoutineStorage";
 
 // Mock main module
-vi.mock('../main', () => ({
+vi.mock("../main", () => ({
   getSettings: vi.fn(),
   updateSettings: vi.fn(),
 }));
 
 // Mock RoutineStorageService
-vi.mock('./RoutineStorage', () => ({
+vi.mock("./RoutineStorage", () => ({
   RoutineStorageService: {
     getActiveRoutine: vi.fn(),
     createRoutine: vi.fn(),
@@ -17,35 +17,80 @@ vi.mock('./RoutineStorage', () => ({
   },
 }));
 
-describe('RoutineService', () => {
+describe("RoutineService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('getExercises', () => {
-    it('should return exercises from active routine', () => {
+  describe("getExercises", () => {
+    it("should return exercises from active routine", () => {
       const mockRoutine = {
-        id: 'test-id',
-        name: 'Test',
-        config: { prepDuration: 10, workDuration: 20, restDuration: 10, rounds: 8, nextExercise: 0 },
-        exercises: ['Jump Squats', 'Push-Ups'],
+        id: "test-id",
+        name: "Test",
+        config: {
+          prepDuration: 10,
+          workDuration: 20,
+          restDuration: 10,
+          rounds: 8,
+          nextExercise: 0,
+        },
+        exercises: ["Jump Squats", "Push-Ups"],
       };
-      vi.mocked(RoutineStorageService.getActiveRoutine).mockReturnValue(mockRoutine);
+      vi.mocked(RoutineStorageService.getActiveRoutine).mockReturnValue(
+        mockRoutine,
+      );
 
       const result = RoutineService.getExercises();
       expect(result).toEqual(mockRoutine.exercises);
     });
   });
 
-  describe('calculateStats', () => {
-    it('should calculate routine statistics from active routine', () => {
+  describe("duplicateExercise", () => {
+    it("should duplicate an exercise in the active routine", () => {
       const mockRoutine = {
-        id: 'test-id',
-        name: 'Test',
-        config: { prepDuration: 10, workDuration: 20, restDuration: 10, rounds: 8, nextExercise: 0 },
-        exercises: ['Jump Squats', 'Push-Ups'],
+        id: "test-id",
+        name: "Test",
+        config: {
+          prepDuration: 10,
+          workDuration: 20,
+          restDuration: 10,
+          rounds: 8,
+          nextExercise: 0,
+        },
+        exercises: ["Jump Squats", "Push-Ups"],
       };
-      vi.mocked(RoutineStorageService.getActiveRoutine).mockReturnValue(mockRoutine);
+      vi.mocked(RoutineStorageService.getActiveRoutine).mockReturnValue(
+        mockRoutine,
+      );
+
+      RoutineService.duplicateExercise(0);
+
+      expect(RoutineStorageService.updateRoutine).toHaveBeenCalledWith(
+        "test-id",
+        {
+          exercises: ["Jump Squats", "Jump Squats", "Push-Ups"],
+        },
+      );
+    });
+  });
+
+  describe("calculateStats", () => {
+    it("should calculate routine statistics from active routine", () => {
+      const mockRoutine = {
+        id: "test-id",
+        name: "Test",
+        config: {
+          prepDuration: 10,
+          workDuration: 20,
+          restDuration: 10,
+          rounds: 8,
+          nextExercise: 0,
+        },
+        exercises: ["Jump Squats", "Push-Ups"],
+      };
+      vi.mocked(RoutineStorageService.getActiveRoutine).mockReturnValue(
+        mockRoutine,
+      );
 
       const stats = RoutineService.calculateStats();
 

--- a/src/assets/routine/RoutineService.ts
+++ b/src/assets/routine/RoutineService.ts
@@ -1,6 +1,6 @@
-import type { RoutineConfig, RoutineStats } from './RoutineTypes';
-import { RoutineStorageService } from './RoutineStorage';
-import { getSettings, updateSettings } from '../main';
+import type { RoutineConfig, RoutineStats } from "./RoutineTypes";
+import { RoutineStorageService } from "./RoutineStorage";
+import { getSettings, updateSettings } from "../main";
 
 export class RoutineService {
   static getExercises(): string[] {
@@ -22,6 +22,23 @@ export class RoutineService {
       // Fallback a formato antiguo
       const settings = getSettings();
       const exercises = [...settings.workouts, name.trim()];
+      updateSettings({ ...settings, workouts: exercises });
+    }
+  }
+
+  static duplicateExercise(index: number): void {
+    const activeRoutine = RoutineStorageService.getActiveRoutine();
+    if (activeRoutine) {
+      const exercises = [...activeRoutine.exercises];
+      const workout = exercises[index];
+      exercises.splice(index + 1, 0, workout);
+      RoutineStorageService.updateRoutine(activeRoutine.id, { exercises });
+    } else {
+      // Fallback a formato antiguo
+      const settings = getSettings();
+      const exercises = [...settings.workouts];
+      const workout = exercises[index];
+      exercises.splice(index + 1, 0, workout);
       updateSettings({ ...settings, workouts: exercises });
     }
   }
@@ -92,7 +109,9 @@ export class RoutineService {
     if (activeRoutine) {
       const currentConfig = activeRoutine.config;
       const newConfig = { ...currentConfig, ...config };
-      RoutineStorageService.updateRoutine(activeRoutine.id, { config: newConfig });
+      RoutineStorageService.updateRoutine(activeRoutine.id, {
+        config: newConfig,
+      });
     } else {
       // Fallback a formato antiguo
       const settings = getSettings();
@@ -105,7 +124,7 @@ export class RoutineService {
     const secondsByExercise = config.workDuration + config.restDuration;
     const minutesByExercise = secondsByExercise / 60;
     const totalMinutes = minutesByExercise * config.rounds;
-    
+
     return {
       totalExercises: this.getExercises().length,
       totalMinutes,

--- a/src/components/CopyIcon.astro
+++ b/src/components/CopyIcon.astro
@@ -1,0 +1,13 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+</svg>

--- a/src/components/SettingsRoutineList.astro
+++ b/src/components/SettingsRoutineList.astro
@@ -1,5 +1,6 @@
 ---
 import AudioOnIcon from "./AudioOnIcon.astro";
+import CopyIcon from "./CopyIcon.astro";
 import DownIcon from "./DownIcon.astro";
 import EditItemIcon from "./EditItemIcon.astro";
 import Plus from "./icons/Plus.icon.astro";
@@ -42,7 +43,9 @@ import UpIcon from "./UpIcon.astro";
 
       <form>
         <fieldset>
-          <label for="edit-item-input" data-i18n="Exercise Name">Exercise Name</label>
+          <label for="edit-item-input" data-i18n="Exercise Name"
+            >Exercise Name</label
+          >
           <input
             type="text"
             name="item"
@@ -53,8 +56,18 @@ import UpIcon from "./UpIcon.astro";
           />
         </fieldset>
         <div class="form-buttons">
-          <button type="button" class="secondary" id="add-edit-modal-cancel" data-i18n="Cancel">Cancel</button>
-          <button type="submit" class="primary" data-i18n-aria-label="Save exercise"><Save /> <span data-i18n="Save">Save</span></button>
+          <button
+            type="button"
+            class="secondary"
+            id="add-edit-modal-cancel"
+            data-i18n="Cancel">Cancel</button
+          >
+          <button
+            type="submit"
+            class="primary"
+            data-i18n-aria-label="Save exercise"
+            ><Save /> <span data-i18n="Save">Save</span></button
+          >
         </div>
       </form>
     </article>
@@ -87,6 +100,13 @@ import UpIcon from "./UpIcon.astro";
             <DownIcon />
           </button>
           <button
+            class="duplicate"
+            data-i18n-title="Duplicate exercise"
+            data-i18n-aria-label="Duplicate exercise"
+          >
+            <CopyIcon />
+          </button>
+          <button
             class="edit"
             data-i18n-title="Edit exercise"
             data-i18n-aria-label="Edit exercise"
@@ -106,9 +126,7 @@ import UpIcon from "./UpIcon.astro";
   </dialog>
 
   <script>
-    import {
-      updateTextContent,
-    } from "../assets/main";
+    import { updateTextContent } from "../assets/main";
     import { RoutineService } from "../assets/routine/RoutineService";
 
     import { onClick } from "@assets/domHelpers";
@@ -183,15 +201,17 @@ import UpIcon from "./UpIcon.astro";
         initTranslation(clone);
 
         item.querySelectorAll("button").forEach((button) => {
-          const { className } = button;
-          if (className.includes("down") && isLastItem) button.disabled = true;
-          if (className.includes("up") && isFirstItem) button.disabled = true;
+          if (button.classList.contains("down") && isLastItem)
+            button.disabled = true;
+          if (button.classList.contains("up") && isFirstItem)
+            button.disabled = true;
 
           button.addEventListener("click", async () => {
-            if (className.includes("delete")) removeWorkout(index);
-            if (className.includes("down")) moveWorkout(index, "down");
-            if (className.includes("up")) moveWorkout(index, "up");
-            if (className.includes("edit")) {
+            if (button.classList.contains("delete")) removeWorkout(index);
+            if (button.classList.contains("duplicate")) duplicateWorkout(index);
+            if (button.classList.contains("down")) moveWorkout(index, "down");
+            if (button.classList.contains("up")) moveWorkout(index, "up");
+            if (button.classList.contains("edit")) {
               const { t } = await import("../assets/dictionary");
               const title = modalAddOrEdit.querySelector(".title");
               if (title) title.textContent = t("Edit Exercise");
@@ -257,6 +277,11 @@ import UpIcon from "./UpIcon.astro";
     const moveWorkout = (fromIdx: number, direction: "up" | "down") => {
       const toIdx = direction === "up" ? fromIdx - 1 : fromIdx + 1;
       RoutineService.moveExercise(fromIdx, toIdx);
+      updateRoutineList();
+    };
+
+    const duplicateWorkout = (index: number) => {
+      RoutineService.duplicateExercise(index);
       updateRoutineList();
     };
 


### PR DESCRIPTION
💡 What: Added a 'Duplicate' button to each exercise in the routine settings.
🎯 Why: Allows users to quickly clone exercises, saving time when creating complex routines.
♿ Accessibility: Added descriptive ARIA labels and titles for the new icon-only button.
📸 Visuals: A new copy icon is now available in the exercise action bar.
🛠️ Technical: Implemented service-level duplication logic and improved component event handling using `classList.contains`.

---
*PR created automatically by Jules for task [8765768462055066876](https://jules.google.com/task/8765768462055066876) started by @galiprandi*