### PR TITLE
🎨 Palette: Enhance Workout Complete page and improve localization consistency

### DIFF
--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -195,10 +195,11 @@ export const dictionary = {
     en: "Turn audio on",
     es: "Activar audio",
   },
-  "Turn audio off": {
-    en: "Turn audio off",
-    es: "Desactivar audio",
-  },
+  "Turn audio off": { en: "Turn audio off", es: "Desactivar audio" },
+  Congrats: { en: "Congrats", es: "Felicidades" },
+  "Are you sure reset all?": { en: "Are you sure you want to reset all settings to default?", es: "¿Estás seguro de que quieres restablecer todos los ajustes por defecto?" },
+  "Start Again": { en: "Start Again", es: "Empezar de nuevo" },
+  "Back to Home": { en: "Back to Home", es: "Volver al inicio" },
 };
 
 const langs: AvailableLanguages[] = ["en", "es"];

--- a/src/components/BackToHome.astro
+++ b/src/components/BackToHome.astro
@@ -1,1 +1,7 @@
-<a href="/tabata">Back to Home</a>
+---
+import Home from '@icons/Home.icon.astro'
+---
+<a href="/tabata" class="button contrast outline"><Home /><span data-i18n="Back to Home">Back to Home</span></a>
+<style>
+  a.button { display: inline-flex; align-items: center; gap: 0.5rem; }
+</style>

--- a/src/components/SettingsTimerConfig.astro
+++ b/src/components/SettingsTimerConfig.astro
@@ -99,6 +99,7 @@ const className = vertical ? "vertical" : "horizontal";
   import { getSettings, updateSettings } from "../assets/main";
   import { defaultSettings } from "../assets/defaultSettings";
   import { updateTotalWorkouts, updateRoutineStats } from "../assets/settings";
+  import { t } from "../assets/dictionary";
   const { prepDuration, workDuration, restDuration, rounds } = getSettings();
 
   function Init() {
@@ -149,7 +150,7 @@ const className = vertical ? "vertical" : "horizontal";
     });
 
     document.getElementById("reset-settings")?.addEventListener("click", () => {
-      if (confirm("Are you sure you want to reset all settings to default?")) {
+      if (confirm(t("Are you sure reset all?"))) {
         updateSettings(defaultSettings);
         window.location.reload();
       }

--- a/src/pages/end.astro
+++ b/src/pages/end.astro
@@ -1,39 +1,31 @@
 ---
 import Layout from '@app/layouts/layout.astro'
 import BackToHome from '@components/BackToHome.astro'
+import Play from '@icons/Play.icon.astro'
 ---
-
 <Layout>
-  <section class="display">
-    <h1>🎉 Congrats 🎉</h1>
-  </section>
-
+  <section class="display"><h1>🎉 <span data-i18n="Congrats">Congrats</span> 🎉</h1></section>
   <footer>
     <div class="columns">
-      <button id="startAgain">Start Again</button>
+      <button id="startAgain"><Play /><span data-i18n="Start Again">Start Again</span></button>
       <BackToHome />
     </div>
   </footer>
 </Layout>
-
 <script>
   import { play } from '@assets/audio'
+  import { onClick } from '@assets/domHelpers'
   document.addEventListener('DOMContentLoaded', () => {
     play('end')
-    document.getElementById('startAgain')?.addEventListener('click', () => {
+    onClick('#startAgain', async () => {
+      await play('tap', true)
       location.href = '/tabata/start'
     })
   })
 </script>
-
 <style>
-  h1 {
-    color: white;
-    font-size: 8vw;
-    font-weight: bold;
-  }
-
-  button#start {
-    min-width: 10em;
-  }
+  h1 { color: white; font-size: 8vw; font-weight: bold; }
+  button#startAgain { min-width: 10em; }
+  .columns { display: flex; flex-direction: column; align-items: center; gap: 1.5rem; }
+  @media (min-width: 450px) { .columns { flex-direction: row; justify-content: center; } }
 </style>


### PR DESCRIPTION
### 🎨 Palette: Enhance Workout Complete page and improve localization consistency

This PR introduces a series of micro-UX improvements focused on the "Workout Complete" experience and overall localization consistency.

#### 💡 What:
- **Workout Complete Page (`end.astro`)**:
    - Wrapped the "Congrats" message in a `<span>` to preserve decorative emojis when translated.
    - Added a `Play` icon to the "Start Again" button.
    - Added audio feedback (`tap` sound) when clicking "Start Again".
    - Updated layout to be responsive (column on mobile, row on larger screens).
- **Back to Home Component (`BackToHome.astro`)**:
    - Transformed from a simple text link to a full-fledged button with the `Home` icon.
    - Added full localization support.
- **Settings Page**:
    - Localized the "Reset to Defaults" confirmation message using the `t()` function.
- **Dictionary**:
    - Added new entries for "Congrats", "Start Again", "Back to Home", and the reset confirmation.

#### 🎯 Why:
- Improves the sense of accomplishment at the end of a workout with a more polished UI.
- Enhances accessibility and internationalization by removing hardcoded strings.
- Provides consistent interactive feedback through icons and audio.

#### ♿ Accessibility:
- Used semantic elements and ensured translatable text is properly tagged.
- Improved touch targets by styling navigation links as buttons.

#### 📸 Before/After:
[View Screenshot](https://galiprandi.github.io/tabata/verification/end_page.png) (Visible in the frontend verification section)

---
*PR created automatically by Jules for task [15345134589295368601](https://jules.google.com/task/15345134589295368601) started by @galiprandi*