### PR TITLE
🎨 Palette: Localize history button accessibility attributes

### DIFF
--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -208,6 +208,7 @@ export const dictionary = {
   "Are you sure reset all?": { en: "Are you sure you want to reset all settings to default?", es: "¿Estás seguro de que quieres restablecer todos los ajustes por defecto?" },
   "Start Again": { en: "Start Again", es: "Empezar de nuevo" },
   "Back to Home": { en: "Back to Home", es: "Volver al inicio" },
+  "See history": { en: "See history", es: "Ver historial" },
 };
 
 const langs: AvailableLanguages[] = ["en", "es"];

--- a/src/components/GoToHistory.astro
+++ b/src/components/GoToHistory.astro
@@ -3,8 +3,10 @@
 
 <button
   class="btn-go-history icon contrast outline"
-  title="Ver historial"
-  aria-label="Ver historial"
+  title="See history"
+  aria-label="See history"
+  data-i18n-title="See history"
+  data-i18n-aria-label="See history"
 >
   <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="10"></circle>


### PR DESCRIPTION
🎨 Palette: Localize history button accessibility attributes

💡 What:
- Added `data-i18n-title` and `data-i18n-aria-label` to the history button in `GoToHistory.astro`.
- Added "See history" translation key to `src/assets/dictionary.ts`.
- Kept English `title` and `aria-label` as defaults for better out-of-the-box accessibility.

🎯 Why:
The history button previously had hardcoded Spanish labels ("Ver historial"), which was inconsistent with the app's English-first approach and lacked proper localization for non-Spanish users.

♿ Accessibility:
- Ensures the icon-only button has accessible labels in both English and Spanish.
- Follows the pattern of using `data-i18n-` attributes to dynamically update standard accessibility attributes.
- Verified with Playwright that the attributes correctly update based on the user's locale.

---
*PR created automatically by Jules for task [13157510465194619831](https://jules.google.com/task/13157510465194619831) started by @galiprandi*