### PR TITLE
🎨 Palette: Improve help component accessibility and localization

### DIFF
--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -3,10 +3,8 @@ export const dictionary = {
     en: "Add new item to the list",
     es: "Agregar nuevo elemento a la lista",
   },
-  Cancel: {
-    en: "Cancel",
-    es: "Cancelar",
-  },
+  Cancel: { en: "Cancel", es: "Cancelar" },
+  Close: { en: "Close", es: "Cerrar" },
   "Config Routine": {
     en: "Config Routine",
     es: "Configurar Rutina",
@@ -209,6 +207,27 @@ export const dictionary = {
   "Start Again": { en: "Start Again", es: "Empezar de nuevo" },
   "Back to Home": { en: "Back to Home", es: "Volver al inicio" },
   "See history": { en: "See history", es: "Ver historial" },
+  "Open help": { en: "Open help", es: "Abrir ayuda" },
+  "Working Time": { en: "Working Time", es: "Tiempo de trabajo" },
+  "Rest Time": { en: "Rest Time", es: "Tiempo de descanso" },
+  "Exercise in Round": { en: "Exercise in Round", es: "Ejercicios por ronda" },
+  "Preparation time prior to the start of the round.": {
+    en: "Preparation time prior to the start of the round.",
+    es: "Tiempo de preparación antes del inicio de la ronda.",
+  },
+  "Working time for each exercise.": {
+    en: "Working time for each exercise.",
+    es: "Tiempo de trabajo para cada ejercicio.",
+  },
+  "Rest time for each exercise.": {
+    en: "Rest time for each exercise.",
+    es: "Tiempo de descanso para cada ejercicio.",
+  },
+  "The total number of exercises per round, which defines the total work time of the round.":
+    {
+      en: "The total number of exercises per round, which defines the total work time of the round.",
+      es: "El número total de ejercicios por ronda, que define el tiempo total de trabajo de la ronda.",
+    },
 };
 
 const langs: AvailableLanguages[] = ["en", "es"];

--- a/src/components/Helper.astro
+++ b/src/components/Helper.astro
@@ -4,68 +4,58 @@ import HelpIcon from '@components/HelpIcon.astro'
 const { title, description } = Astro.props
 ---
 
-<button
-  title={title}
-  class="btn-open-dialog"
-  data-title={title}
-  data-description={description}
-  data-i18n-aria-label="Open help"
-  data-i18n-title="Open help"
->
-  <HelpIcon />
-</button>
-
-<dialog class="help-modal">
-  <article>
-    <header>
-      <h3 class="title"></h3>
-    </header>
-    <div class="content">
-      <p class="description"></p>
-    </div>
-    <footer>
-      <button
-        data-i18n-title="Close"
-        data-i18n="Close"
-        class="contrast btn-close-dialog">Close</button
-      >
-    </footer>
-  </article>
-</dialog>
+<div class="helper-container">
+  <button
+    title={title}
+    class="btn-open-dialog"
+    data-title={title}
+    data-description={description}
+    data-i18n-aria-label="Open help"
+    data-i18n-title="Open help"
+  >
+    <HelpIcon />
+  </button>
+  <dialog class="help-modal">
+    <article>
+      <header><h3 class="title"></h3></header>
+      <div class="content"><p class="description"></p></div>
+      <footer>
+        <button
+          data-i18n-title="Close"
+          data-i18n="Close"
+          class="contrast btn-close-dialog">Close</button
+        >
+      </footer>
+    </article>
+  </dialog>
+</div>
 
 <script>
-  const dialog = document.querySelector(
-    '.help-modal'
-  ) as HTMLDialogElement | null
-  const btnOpen = document.querySelectorAll(
-    '.btn-open-dialog'
-  ) as NodeListOf<HTMLButtonElement> | null
-  const btnClose = document.querySelector(
-    '.btn-close-dialog'
-  ) as HTMLButtonElement | null
-
-  if (dialog && btnOpen) {
-    btnOpen.forEach(btn => {
-      btn.addEventListener('click', () => {
-        const title = btn.getAttribute('data-title')
-        const description = btn.getAttribute('data-description')
-
-        const titleEl = dialog.querySelector('.title')
-        const descEl = dialog.querySelector('.description')
-
-        if (titleEl && title) titleEl.textContent = title
-        if (descEl && description) descEl.textContent = description
-
-        dialog.showModal()
-      })
+  import { t, initTranslation } from '@assets/dictionary'
+  document.querySelectorAll('.helper-container').forEach(container => {
+    const btnOpen = container.querySelector('.btn-open-dialog') as any
+    const dialog = container.querySelector('.help-modal') as any
+    const btnClose = container.querySelector('.btn-close-dialog') as any
+    initTranslation(container as any)
+    btnOpen.addEventListener('click', () => {
+      dialog.querySelector('.title').textContent = t(btnOpen.dataset.title)
+      dialog.querySelector('.description').textContent = t(
+        btnOpen.dataset.description
+      )
+      dialog.showModal()
+      btnClose.focus()
     })
-  }
-
-  if (dialog && btnClose) {
     btnClose.addEventListener('click', () => {
       dialog.close()
+      btnOpen.focus()
     })
-  }
+    dialog.addEventListener('click', e => {
+      if (e.target === dialog) {
+        dialog.close()
+        btnOpen.focus()
+      }
+    })
+  })
 </script>
 
 <style>

--- a/src/components/SettingsTimerConfig.astro
+++ b/src/components/SettingsTimerConfig.astro
@@ -38,7 +38,8 @@ const className = vertical ? "vertical" : "horizontal";
           id="prepDuration"
           class="prep"
           min="0"
-          aria-label="Preparation duration in seconds"
+          data-i18n-aria-label="Preparation Time"
+          aria-label="Preparation Time"
         />
       </label>
       <Helper
@@ -54,7 +55,8 @@ const className = vertical ? "vertical" : "horizontal";
           id="workDuration"
           class="workout"
           min="0"
-          aria-label="Work duration in seconds"
+          data-i18n-aria-label="Working Time"
+          aria-label="Working Time"
         />
       </label>
       <Helper
@@ -70,7 +72,8 @@ const className = vertical ? "vertical" : "horizontal";
           id="restDuration"
           class="rest"
           min="0"
-          aria-label="Rest duration in seconds"
+          data-i18n-aria-label="Rest Time"
+          aria-label="Rest Time"
         />
       </label>
       <Helper title="Rest Time" description="Rest time for each exercise." />
@@ -84,7 +87,8 @@ const className = vertical ? "vertical" : "horizontal";
           class="rest"
           min="0"
           step="1"
-          aria-label="Number of rounds"
+          data-i18n-aria-label="Exercise in Round"
+          aria-label="Exercise in Round"
         />
       </label>
       <Helper


### PR DESCRIPTION
This PR implements several micro-UX improvements to the Tabata app:

1.  **Accessibility**: The help modal now manages focus correctly (moving it to the 'Close' button on open and back to the trigger on close) and can be dismissed by clicking the backdrop.
2.  **Internationalization**: The help component now supports localized titles and descriptions. I've also updated the timer settings inputs to use localized ARIA labels.
3.  **Scoped Logic**: Refactored the Helper component's script to use scoped selectors, ensuring that multiple help icons on the same page don't conflict with each other.
4.  **Localization Coverage**: Added several missing Spanish translation keys to the dictionary.

These changes make the settings interface more professional, accessible, and inclusive for Spanish-speaking users.

---
*PR created automatically by Jules for task [4830595017450569577](https://jules.google.com/task/4830595017450569577) started by @galiprandi*