### PR TITLE
🎨 Palette: Improve Helper component accessibility and feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,8 @@
 
 **Learning:** When using shared templates with multiple action buttons, identifying buttons by simple substrings (e.g., `className.includes("up")`) is brittle and can lead to multiple actions being triggered if class names overlap (e.g., "up" matching "duplicate").
 **Action:** Use `element.classList.contains()` for exact class matching to ensure one button triggers exactly one intended action.
+
+## 2025-07-15 - [Modal Focus Management]
+
+**Learning:** To ensure keyboard accessibility in help components, focus must be programmatically shifted to the close button when a dialog opens and returned to the trigger button when it closes.
+**Action:** When implementing native `<dialog>` elements, use `dialog.showModal()`, focus the close button immediately, and use a `once: true` listener on the 'close' event to restore focus.

--- a/src/components/Helper.astro
+++ b/src/components/Helper.astro
@@ -34,6 +34,8 @@ const { title, description } = Astro.props
 </dialog>
 
 <script>
+  import { play } from '@assets/audio'
+
   const dialog = document.querySelector(
     '.help-modal'
   ) as HTMLDialogElement | null
@@ -46,7 +48,8 @@ const { title, description } = Astro.props
 
   if (dialog && btnOpen) {
     btnOpen.forEach(btn => {
-      btn.addEventListener('click', () => {
+      btn.addEventListener('click', async () => {
+        await play('tap', true)
         const title = btn.getAttribute('data-title')
         const description = btn.getAttribute('data-description')
 
@@ -57,12 +60,16 @@ const { title, description } = Astro.props
         if (descEl && description) descEl.textContent = description
 
         dialog.showModal()
+        btnClose?.focus()
+
+        dialog.addEventListener('close', () => btn.focus(), { once: true })
       })
     })
   }
 
   if (dialog && btnClose) {
-    btnClose.addEventListener('click', () => {
+    btnClose.addEventListener('click', async () => {
+      await play('tap', true)
       dialog.close()
     })
   }


### PR DESCRIPTION
Improved the `Helper.astro` component by implementing programmatic focus management and adding audio feedback. When the help modal opens, focus is now automatically moved to the 'Close' button. When the modal is closed, focus is returned to the original trigger button. Additionally, both opening and closing the help dialog now trigger the standard 'tap' audio feedback. These changes improve accessibility (WCAG 2.1 Focus Order) and user engagement with minimal code impact.

---
*PR created automatically by Jules for task [6902542325018336090](https://jules.google.com/task/6902542325018336090) started by @galiprandi*