### PR TITLE
🎨 Palette: Add search clear button and fix helper focus

### DIFF
--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -224,6 +224,10 @@ export const dictionary = {
     en: "Failed to generate link",
     es: "Error al generar el enlace",
   },
+  "Clear search": {
+    en: "Clear search",
+    es: "Limpiar búsqueda",
+  },
 };
 
 const langs: AvailableLanguages[] = ["en", "es"];

--- a/src/components/Helper.astro
+++ b/src/components/Helper.astro
@@ -1,7 +1,7 @@
 ---
-import HelpIcon from '@components/HelpIcon.astro'
+import HelpIcon from "@components/HelpIcon.astro";
 
-const { title, description } = Astro.props
+const { title, description } = Astro.props;
 ---
 
 <div class="helper-container">
@@ -31,52 +31,50 @@ const { title, description } = Astro.props
 </div>
 
 <script>
-  import { play } from '@assets/audio'
+  import { play } from "@assets/audio";
 
   const dialog = document.querySelector(
-    '.help-modal'
-  ) as HTMLDialogElement | null
+    ".help-modal",
+  ) as HTMLDialogElement | null;
   const btnOpen = document.querySelectorAll(
-    '.btn-open-dialog'
-  ) as NodeListOf<HTMLButtonElement> | null
+    ".btn-open-dialog",
+  ) as NodeListOf<HTMLButtonElement> | null;
   const btnClose = document.querySelector(
-    '.btn-close-dialog'
-  ) as HTMLButtonElement | null
+    ".btn-close-dialog",
+  ) as HTMLButtonElement | null;
 
   if (dialog && btnOpen) {
-    btnOpen.forEach(btn => {
-      btn.addEventListener('click', async () => {
-        await play('tap', true)
-        const title = btn.getAttribute('data-title')
-        const description = btn.getAttribute('data-description')
+    btnOpen.forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        await play("tap", true);
+        const title = btn.getAttribute("data-title");
+        const description = btn.getAttribute("data-description");
 
-        const titleEl = dialog.querySelector('.title')
-        const descEl = dialog.querySelector('.description')
+        const titleEl = dialog.querySelector(".title");
+        const descEl = dialog.querySelector(".description");
 
-        if (titleEl && title) titleEl.textContent = title
-        if (descEl && description) descEl.textContent = description
+        if (titleEl && title) titleEl.textContent = title;
+        if (descEl && description) descEl.textContent = description;
 
-        dialog.showModal()
-        btnClose?.focus()
+        dialog.showModal();
+        btnClose?.focus();
 
-        dialog.addEventListener('close', () => btn.focus(), { once: true })
-      })
-    })
+        dialog.addEventListener("close", () => btn.focus(), { once: true });
+      });
+    });
   }
 
   if (dialog && btnClose) {
-    btnClose.addEventListener('click', async () => {
-      await play('tap', true)
-      dialog.close()
-      btnOpen.focus()
-    })
-    dialog.addEventListener('click', e => {
+    btnClose.addEventListener("click", async () => {
+      await play("tap", true);
+      dialog.close();
+    });
+    dialog.addEventListener("click", (e) => {
       if (e.target === dialog) {
-        dialog.close()
-        btnOpen.focus()
+        dialog.close();
       }
-    })
-  })
+    });
+  }
 </script>
 
 <style>

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -27,6 +27,28 @@
     data-i18n-aria-label="Search routine or exercise..."
     aria-label="Search routine or exercise..."
   />
+  <button
+    class="clear-button"
+    id="clear-search"
+    data-i18n-title="Clear search"
+    data-i18n-aria-label="Clear search"
+    style="display: none;"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <line x1="18" y1="6" x2="6" y2="18"></line>
+      <line x1="6" y1="6" x2="18" y2="18"></line>
+    </svg>
+  </button>
 </div>
 
 <style>
@@ -69,18 +91,50 @@
   .search-input::placeholder {
     color: var(--text-muted);
   }
+
+  #clear-search {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    padding: 0.2rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition:
+      background-color 0.2s,
+      color 0.2s;
+    min-width: 32px;
+    min-height: 32px;
+  }
+
+  #clear-search:hover {
+    background-color: var(--surface-hover);
+    color: var(--text-primary);
+  }
 </style>
 
 <script>
+  import { play } from "@assets/audio";
+
   const searchInput = document.querySelector(
     ".search-input",
   ) as HTMLInputElement;
+  const clearButton = document.getElementById(
+    "clear-search",
+  ) as HTMLButtonElement;
 
-  if (searchInput) {
+  if (searchInput && clearButton) {
     let debounceTimer: number;
+
+    const updateClearButtonVisibility = () => {
+      clearButton.style.display = searchInput.value ? "inline-flex" : "none";
+    };
 
     searchInput.addEventListener("input", (e) => {
       const query = (e.target as HTMLInputElement).value;
+      updateClearButtonVisibility();
 
       clearTimeout(debounceTimer);
       debounceTimer = window.setTimeout(() => {
@@ -90,5 +144,20 @@
         document.dispatchEvent(searchEvent);
       }, 300);
     });
+
+    clearButton.addEventListener("click", async () => {
+      await play("tap", true);
+      searchInput.value = "";
+      updateClearButtonVisibility();
+      searchInput.focus();
+
+      const searchEvent = new CustomEvent("search", {
+        detail: { query: "" },
+      });
+      document.dispatchEvent(searchEvent);
+    });
+
+    // Initial state
+    updateClearButtonVisibility();
   }
 </script>


### PR DESCRIPTION
🎨 Palette: Add search clear button

💡 What: Added a "Clear" button to the search bar component that allows users to reset their search query with a single click.

🎯 Why: Enhances usability by providing a quick way to reset filters, especially useful for mobile users who might find clearing long text strings tedious.

♿ Accessibility:
- Added `aria-label` and `title` to the clear button (localized).
- The button is keyboard accessible.
- Focus is programmatically returned to the search input after clearing.
- Fixed a pre-existing issue in `Helper.astro` where focus was not correctly handled during modal closure.

📸 Verification: Visual confirmation completed via Playwright. Clear button appears only when text is present, resets input on click, and maintains focus on the input field.

---
*PR created automatically by Jules for task [3030483349142135862](https://jules.google.com/task/3030483349142135862) started by @galiprandi*