### PR TITLE
🎨 Palette: Improve trainer view search empty state

### DIFF
--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -230,22 +230,29 @@ export const dictionary = {
   },
   History: { en: "History", es: "Historial" },
   "See history": { en: "See history", es: "Ver historial" },
-  "Workout History": { en: "Workout History", es: "Historial de entrenamientos" },
+  "Workout History": {
+    en: "Workout History",
+    es: "Historial de entrenamientos",
+  },
   "Clear History": { en: "Clear History", es: "Limpiar historial" },
   "No workouts recorded yet. Start training to see your history!": {
     en: "No workouts recorded yet. Start training to see your history!",
     es: "Aún no hay entrenamientos registrados. ¡Empieza a entrenar para ver tu historial!",
   },
-  "Are you sure you want to clear all workout history? This cannot be undone.": {
-    en: "Are you sure you want to clear all workout history? This cannot be undone.",
-    es: "¿Estás seguro de que quieres borrar todo el historial de entrenamientos? Esto no se puede deshacer.",
-  },
+  "Are you sure you want to clear all workout history? This cannot be undone.":
+    {
+      en: "Are you sure you want to clear all workout history? This cannot be undone.",
+      es: "¿Estás seguro de que quieres borrar todo el historial de entrenamientos? Esto no se puede deshacer.",
+    },
   "Trainer Mode": { en: "Trainer Mode", es: "Modo Entrenador" },
   "No routines. Create the first one to start.": {
     en: "No routines. Create the first one to start.",
     es: "No hay rutinas. Crea la primera para empezar.",
   },
-  "Overall Statistics": { en: "Overall Statistics", es: "Estadísticas generales" },
+  "Overall Statistics": {
+    en: "Overall Statistics",
+    es: "Estadísticas generales",
+  },
   "Total Workouts": { en: "Total Workouts", es: "Total de entrenamientos" },
   "Total Time": { en: "Total Time", es: "Tiempo total" },
   "Current Streak": { en: "Current Streak", es: "Racha actual" },
@@ -258,9 +265,18 @@ export const dictionary = {
     en: "Failed to generate progress link",
     es: "Error al generar el enlace de progreso",
   },
-  "Routine Statistics": { en: "Routine Statistics", es: "Estadísticas de rutinas" },
-  "Exercise Statistics": { en: "Exercise Statistics", es: "Estadísticas de ejercicios" },
-  "No workout data yet.": { en: "No workout data yet.", es: "Aún no hay datos de entrenamiento." },
+  "Routine Statistics": {
+    en: "Routine Statistics",
+    es: "Estadísticas de rutinas",
+  },
+  "Exercise Statistics": {
+    en: "Exercise Statistics",
+    es: "Estadísticas de ejercicios",
+  },
+  "No workout data yet.": {
+    en: "No workout data yet.",
+    es: "Aún no hay datos de entrenamiento.",
+  },
   "Workouts:": { en: "Workouts:", es: "Entrenamientos:" },
   "Avg:": { en: "Avg:", es: "Promedio:" },
   "Frequency:": { en: "Frequency:", es: "Frecuencia:" },
@@ -279,6 +295,10 @@ export const dictionary = {
   "Open help": {
     en: "Open help",
     es: "Abrir ayuda",
+  },
+  "No results found for your search": {
+    en: "No results found for your search",
+    es: "No se encontraron resultados para tu búsqueda",
   },
 };
 

--- a/src/pages/trainer.astro
+++ b/src/pages/trainer.astro
@@ -41,25 +41,48 @@ import SearchBar from "@components/SearchBar.astro";
     <div id="routine-list" class="routine-list"></div>
 
     <div id="empty-state" class="empty-state">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="48"
-        height="48"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <path
-          d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"
-        ></path>
-        <circle cx="12" cy="13" r="3"></circle>
-      </svg>
-      <p data-i18n="No routines. Create the first one to start.">
-        No routines. Create the first one to start.
-      </p>
+      <div id="no-routines-msg">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path
+            d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"
+          ></path>
+          <circle cx="12" cy="13" r="3"></circle>
+        </svg>
+        <p data-i18n="No routines. Create the first one to start.">
+          No routines. Create the first one to start.
+        </p>
+      </div>
+      <div id="no-results-msg" style="display: none;">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+        <p data-i18n="No results found for your search">
+          No results found for your search
+        </p>
+      </div>
     </div>
   </section>
 </Layout>
@@ -77,14 +100,24 @@ import SearchBar from "@components/SearchBar.astro";
     return div.innerHTML;
   }
 
-  function renderRoutines(routinesToRender: Routine[]) {
+  function renderRoutines(routinesToRender: Routine[], isSearch = false) {
     const list = document.getElementById("routine-list");
     const emptyState = document.getElementById("empty-state");
-    if (!list || !emptyState) return;
+    const noRoutinesMsg = document.getElementById("no-routines-msg");
+    const noResultsMsg = document.getElementById("no-results-msg");
+
+    if (!list || !emptyState || !noRoutinesMsg || !noResultsMsg) return;
 
     if (routinesToRender.length === 0) {
       list.innerHTML = "";
       emptyState.style.display = "flex";
+      if (isSearch) {
+        noRoutinesMsg.style.display = "none";
+        noResultsMsg.style.display = "block";
+      } else {
+        noRoutinesMsg.style.display = "block";
+        noResultsMsg.style.display = "none";
+      }
       return;
     }
 
@@ -166,7 +199,8 @@ import SearchBar from "@components/SearchBar.astro";
     const allRoutines = RoutineStorageService.getRoutines();
     let filtered = allRoutines;
 
-    if (query.trim()) {
+    const isSearch = query.trim().length > 0;
+    if (isSearch) {
       const q = query.toLowerCase();
       filtered = allRoutines.filter(
         (r) =>
@@ -175,7 +209,7 @@ import SearchBar from "@components/SearchBar.astro";
       );
     }
 
-    renderRoutines(filtered);
+    renderRoutines(filtered, isSearch);
   }
 
   async function handleShare(routineId: string) {


### PR DESCRIPTION
This PR improves the micro-UX of the Trainer view by providing more specific feedback when a search filter yields no results. Instead of seeing a generic "No routines" message that prompts the user to create their first routine, they now see a specific "No results found for your search" message with a relevant icon. This reduces confusion and makes the search feature feel more polished and intuitive. Additionally, decorative icons in these empty states were marked with `aria-hidden="true"` to improve screen reader accessibility.

---
*PR created automatically by Jules for task [10330126634453855145](https://jules.google.com/task/10330126634453855145) started by @galiprandi*