### PR TITLE
🎨 Palette: UX and accessibility improvements for routine lists

### DIFF
--- a/src/components/Helper.astro
+++ b/src/components/Helper.astro
@@ -12,6 +12,7 @@ const { title, description } = Astro.props;
     data-description={description}
     data-i18n-aria-label="Open help"
     data-i18n-title="Open help"
+    data-tooltip={title || "Open help"}
   >
     <HelpIcon />
   </button>

--- a/src/components/RoutineList.astro
+++ b/src/components/RoutineList.astro
@@ -4,7 +4,7 @@ import TrashIcon from "./TrashIcon.astro";
 import EditItemIcon from "./EditItemIcon.astro";
 ---
 
-<section id="routine-list">
+<section id="my-routines-section">
   <h2 data-i18n="My Routines">My Routines</h2>
   <section id="routines-list">
     <span aria-busy="true" data-i18n="Loading...">Loading...</span>
@@ -75,6 +75,7 @@ import EditItemIcon from "./EditItemIcon.astro";
           class="select"
           data-i18n-title="Select routine"
           data-i18n-aria-label="Select routine"
+          data-tooltip="Select routine"
         >
           ✓
         </button>
@@ -82,6 +83,7 @@ import EditItemIcon from "./EditItemIcon.astro";
           class="edit"
           data-i18n-title="Edit routine"
           data-i18n-aria-label="Edit routine"
+          data-tooltip="Edit routine"
         >
           <EditItemIcon />
         </button>
@@ -105,6 +107,7 @@ import EditItemIcon from "./EditItemIcon.astro";
           class="delete"
           data-i18n-title="Delete routine"
           data-i18n-aria-label="Delete routine"
+          data-tooltip="Delete routine"
         >
           <TrashIcon />
         </button>
@@ -127,6 +130,34 @@ import EditItemIcon from "./EditItemIcon.astro";
     "routine-name",
   ) as HTMLInputElement | null;
 
+  const handleOpenModal = async (
+    trigger: HTMLElement,
+    titleText: string,
+    routineId?: string,
+    routineName?: string,
+  ) => {
+    if (!routineModal || !routineNameInput) return;
+    await play("tap", true);
+    const title = routineModal.querySelector(".title");
+    if (title) title.textContent = titleText;
+    routineNameInput.value = routineName || "";
+    if (routineId) {
+      routineModal.dataset.routineId = routineId;
+    } else {
+      delete routineModal.dataset.routineId;
+    }
+    routineModal.showModal();
+    routineNameInput.focus();
+
+    routineModal.addEventListener(
+      "close",
+      () => {
+        trigger.focus();
+      },
+      { once: true },
+    );
+  };
+
   const updateRoutineList = () => {
     if (!routineModal) throw new Error("Modal not found");
     if (!routineNameInput) throw new Error("Input not found");
@@ -135,7 +166,9 @@ import EditItemIcon from "./EditItemIcon.astro";
     const activeRoutineId = RoutineStorageService.getActiveRoutineId();
     const routinesList = document.getElementById("routines-list");
     const emptyState = document.getElementById("empty-routines-state");
-    const buttonsSection = document.querySelector("#routine-list > .buttons");
+    const buttonsSection = document.querySelector(
+      "#my-routines-section > .buttons",
+    );
     const template = document.getElementById(
       "routine-item-template",
     ) as HTMLTemplateElement;
@@ -181,12 +214,12 @@ import EditItemIcon from "./EditItemIcon.astro";
             updateRoutineList();
           }
           if (button.classList.contains("edit")) {
-            const title = routineModal.querySelector(".title");
-            if (title) title.textContent = t("Edit Routine");
-            routineNameInput.value = routine.name;
-            routineModal.dataset.routineId = routine.id;
-            routineModal.showModal();
-            routineNameInput.focus();
+            await handleOpenModal(
+              button,
+              t("Edit Routine"),
+              routine.id,
+              routine.name,
+            );
           }
           if (button.classList.contains("share")) {
             const result = compressRoutine(routine);
@@ -236,23 +269,13 @@ import EditItemIcon from "./EditItemIcon.astro";
     if (!routineNameInput) throw new Error("Input not found");
 
     onClick("#add-new-routine", async () => {
-      await play("tap", true);
-      const title = routineModal.querySelector(".title");
-      if (title) title.textContent = t("New Routine");
-      routineNameInput.value = "";
-      delete routineModal.dataset.routineId;
-      routineModal.showModal();
-      routineNameInput.focus();
+      const trigger = document.getElementById("add-new-routine");
+      if (trigger) await handleOpenModal(trigger, t("New Routine"));
     });
 
     onClick("#add-first-routine", async () => {
-      await play("tap", true);
-      const title = routineModal.querySelector(".title");
-      if (title) title.textContent = t("New Routine");
-      routineNameInput.value = "";
-      delete routineModal.dataset.routineId;
-      routineModal.showModal();
-      routineNameInput.focus();
+      const trigger = document.getElementById("add-first-routine");
+      if (trigger) await handleOpenModal(trigger, t("New Routine"));
     });
 
     onClick("#routine-modal-cancel", async () => {
@@ -298,7 +321,7 @@ import EditItemIcon from "./EditItemIcon.astro";
 </script>
 
 <style>
-  #routine-list h2 {
+  #my-routines-section h2 {
     font-size: 1.25rem;
     font-weight: 700;
     color: var(--text-primary);
@@ -393,7 +416,7 @@ import EditItemIcon from "./EditItemIcon.astro";
     }
   }
 
-  #routine-list > .buttons button {
+  #my-routines-section > .buttons button {
     min-height: var(--touch-target-lg);
     font-size: 1rem;
     font-weight: 600;

--- a/src/components/RoutineSelector.astro
+++ b/src/components/RoutineSelector.astro
@@ -10,6 +10,7 @@
     aria-expanded="false"
     data-i18n-aria-label="Select routine"
     data-i18n-title="Select routine"
+    data-tooltip="Select routine"
   >
     <span id="current-routine-name" data-i18n="Loading...">Loading...</span>
     <svg

--- a/src/components/SettingsRoutineList.astro
+++ b/src/components/SettingsRoutineList.astro
@@ -9,7 +9,7 @@ import TrashIcon from "./TrashIcon.astro";
 import UpIcon from "./UpIcon.astro";
 ---
 
-<section id="routine-list">
+<section id="exercises-section">
   <h2 data-i18n="Routine">Routine</h2>
   <section id="workouts-list">
     <span aria-busy="true" data-i18n="Loading...">Loading...</span>
@@ -182,7 +182,9 @@ import UpIcon from "./UpIcon.astro";
       const exercises = RoutineService.getExercises();
       const workoutsList = document.getElementById("workouts-list");
       const emptyState = document.getElementById("empty-routine-state");
-      const buttonsSection = document.querySelector("#routine-list > .buttons");
+      const buttonsSection = document.querySelector(
+        "#exercises-section > .buttons",
+      );
       const template = document.getElementById(
         "workout-item-template",
       ) as HTMLTemplateElement;
@@ -232,12 +234,12 @@ import UpIcon from "./UpIcon.astro";
             if (button.classList.contains("up")) moveWorkout(index, "up");
             if (button.classList.contains("edit")) {
               const { t } = await import("../assets/dictionary");
-              const title = modalAddOrEdit.querySelector(".title");
-              if (title) title.textContent = t("Edit Exercise");
-              formAddEditItems.dataset.idx = index.toString();
-              inputAddEditItems.value = workout;
-              modalAddOrEdit.showModal();
-              inputAddEditItems.focus();
+              await handleOpenModal(
+                button,
+                t("Edit Exercise"),
+                index.toString(),
+                workout,
+              );
             }
           });
         });
@@ -245,6 +247,29 @@ import UpIcon from "./UpIcon.astro";
         workoutsList?.appendChild(clone);
       });
       speechOnTap();
+    };
+
+    const handleOpenModal = async (
+      trigger: HTMLElement,
+      titleText: string,
+      idx?: string,
+      name?: string,
+    ) => {
+      await play("tap", true);
+      const title = modalAddOrEdit?.querySelector(".title");
+      if (title) title.textContent = titleText;
+      if (formAddEditItems) formAddEditItems.dataset.idx = idx || "";
+      if (inputAddEditItems) inputAddEditItems.value = name || "";
+      modalAddOrEdit?.showModal();
+      inputAddEditItems?.focus();
+
+      modalAddOrEdit?.addEventListener(
+        "close",
+        () => {
+          trigger.focus();
+        },
+        { once: true },
+      );
     };
 
     const init = async () => {
@@ -257,27 +282,15 @@ import UpIcon from "./UpIcon.astro";
       if (!formAddEditItems) throw new Error("Form not found");
 
       onClick("#add-new-item", async () => {
-        await play("tap", true);
+        const trigger = document.getElementById("add-new-item");
         const { t } = await import("../assets/dictionary");
-        const title = modalAddOrEdit.querySelector(".title");
-        if (title) title.textContent = t("New Exercise");
-        if (!formAddEditItems) return;
-        formAddEditItems.dataset.idx = "";
-        inputAddEditItems.value = "";
-        modalAddOrEdit.showModal();
-        inputAddEditItems.focus();
+        if (trigger) await handleOpenModal(trigger, t("New Exercise"));
       });
 
       onClick("#add-first-item", async () => {
-        await play("tap", true);
+        const trigger = document.getElementById("add-first-item");
         const { t } = await import("../assets/dictionary");
-        const title = modalAddOrEdit.querySelector(".title");
-        if (title) title.textContent = t("New Exercise");
-        if (!formAddEditItems) return;
-        formAddEditItems.dataset.idx = "";
-        inputAddEditItems.value = "";
-        modalAddOrEdit.showModal();
-        inputAddEditItems.focus();
+        if (trigger) await handleOpenModal(trigger, t("New Exercise"));
       });
 
       onClick("#add-edit-modal-cancel", async () => {
@@ -332,7 +345,7 @@ import UpIcon from "./UpIcon.astro";
   </script>
 
   <style>
-    #routine-list h2 {
+    #exercises-section h2 {
       font-size: 1.25rem;
       font-weight: 700;
       color: var(--text-primary);
@@ -493,7 +506,7 @@ import UpIcon from "./UpIcon.astro";
       }
     }
 
-    #routine-list > .buttons button {
+    #exercises-section > .buttons button {
       min-height: var(--touch-target-lg);
       font-size: 1rem;
       font-weight: 600;


### PR DESCRIPTION
### 💡 What: UX enhancement added
Implemented several micro-UX and accessibility improvements focused on the settings page and routine management.

- **Fixed Duplicate IDs**: Renamed the root section IDs in `RoutineList.astro` and `SettingsRoutineList.astro` to `my-routines-section` and `exercises-section` respectively. This resolves an issue where both components were using the same ID on the settings page, which was invalid HTML and could cause script selector conflicts.
- **Added Tooltips**: Added missing `data-tooltip` attributes to icon-only buttons (Select, Edit, Delete, Help) in `RoutineList.astro`, `RoutineSelector.astro`, and `Helper.astro`.
- **Focus Management**: Implemented focus return for the modals in both routine components. When a modal is closed, focus is now programmatically returned to the button that triggered it.

### 🎯 Why: The user problem it solves
- **Duplicate IDs**: Prevents fragile selector behavior and ensures HTML validity.
- **Tooltips**: Provides visual feedback and clarity for icon-only actions, adhering to the app's use of Pico CSS tooltips.
- **Focus Return**: Improves keyboard navigation and screen reader experience by maintaining context after closing a modal.

### ♿ Accessibility: Any a11y improvements made
- Fixed focus trap/loss issue by returning focus to the trigger element after modal closure.
- Improved context for icon-only buttons via tooltips.
- Ensured unique IDs for better DOM tree structure for assistive technologies.

---
*PR created automatically by Jules for task [15028303955860172953](https://jules.google.com/task/15028303955860172953) started by @galiprandi*