### PR TITLE
🎨 Palette: Implement Web Share API for better mobile sharing

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,8 @@
 
 **Learning:** To ensure keyboard accessibility in help components, focus must be programmatically shifted to the close button when a dialog opens and returned to the trigger button when it closes.
 **Action:** When implementing native `<dialog>` elements, use `dialog.showModal()`, focus the close button immediately, and use a `once: true` listener on the 'close' event to restore focus.
+
+## 2025-08-15 - [Native Sharing UX]
+
+**Learning:** Implementing the native Web Share API (`navigator.share`) significantly improves the sharing experience on mobile devices, making it feel like a first-class app interaction. A robust fallback to clipboard copying ensures functionality on all platforms.
+**Action:** Use native sharing when possible, providing translatable titles and text, and always include a clipboard fallback with user feedback (e.g., localized alerts).

--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -300,6 +300,10 @@ export const dictionary = {
     en: "No results found for your search",
     es: "No se encontraron resultados para tu búsqueda",
   },
+  "Share Progress": {
+    en: "Share Progress",
+    es: "Compartir progreso",
+  },
 };
 
 const langs: AvailableLanguages[] = ["en", "es"];

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -1,11 +1,11 @@
 ---
-import Layout from '../layouts/layout.astro'
-import StatsDashboard from '../components/StatsDashboard.astro'
-import WorkoutHistory from '../components/WorkoutHistory.astro'
-import RoutineStats from '../components/RoutineStats.astro'
-import ExerciseStats from '../components/ExerciseStats.astro'
-import ShareProgressButton from '../components/ShareProgressButton.astro'
-import GoToHome from '../components/GoToHome.astro'
+import Layout from "../layouts/layout.astro";
+import StatsDashboard from "../components/StatsDashboard.astro";
+import WorkoutHistory from "../components/WorkoutHistory.astro";
+import RoutineStats from "../components/RoutineStats.astro";
+import ExerciseStats from "../components/ExerciseStats.astro";
+import ShareProgressButton from "../components/ShareProgressButton.astro";
+import GoToHome from "../components/GoToHome.astro";
 ---
 
 <Layout>
@@ -19,14 +19,14 @@ import GoToHome from '../components/GoToHome.astro'
     <div class="history-header">
       <ShareProgressButton />
     </div>
-    
+
     <StatsDashboard />
-    
+
     <div class="stats-grid">
       <RoutineStats />
       <ExerciseStats />
     </div>
-    
+
     <WorkoutHistory />
   </section>
 </Layout>
@@ -36,7 +36,7 @@ import GoToHome from '../components/GoToHome.astro'
   import { compressProgress, getDateRanges } from "../assets/progressSharing";
   import { t } from "../assets/dictionary";
 
-  document.addEventListener("share-progress", () => {
+  document.addEventListener("share-progress", async () => {
     const logs = WorkoutLogService.getLogs();
     const ranges = getDateRanges();
 
@@ -44,8 +44,23 @@ import GoToHome from '../components/GoToHome.astro'
     const result = compressProgress(logs, ranges[0], "My Progress");
 
     if (result.success && result.url) {
-      navigator.clipboard.writeText(result.url);
-      alert(t("Progress link copied to clipboard!"));
+      if (navigator.share) {
+        try {
+          await navigator.share({
+            title: t("Workout History"),
+            text: t("Share Progress"),
+            url: result.url,
+          });
+        } catch (err) {
+          if ((err as Error).name !== "AbortError") {
+            navigator.clipboard.writeText(result.url);
+            alert(t("Progress link copied to clipboard!"));
+          }
+        }
+      } else {
+        navigator.clipboard.writeText(result.url);
+        alert(t("Progress link copied to clipboard!"));
+      }
     } else {
       alert(t("Failed to generate progress link"));
     }

--- a/src/pages/trainer.astro
+++ b/src/pages/trainer.astro
@@ -221,8 +221,23 @@ import SearchBar from "@components/SearchBar.astro";
 
     const result = compressRoutine(routine);
     if (result.success && result.url) {
-      navigator.clipboard.writeText(result.url);
-      alert(t("Link copied to clipboard"));
+      if (navigator.share) {
+        try {
+          await navigator.share({
+            title: routine.name,
+            text: t("Share routine"),
+            url: result.url,
+          });
+        } catch (err) {
+          if ((err as Error).name !== "AbortError") {
+            navigator.clipboard.writeText(result.url);
+            alert(t("Link copied to clipboard"));
+          }
+        }
+      } else {
+        navigator.clipboard.writeText(result.url);
+        alert(t("Link copied to clipboard"));
+      }
     } else {
       alert(t("Failed to generate link"));
     }


### PR DESCRIPTION
This change enhances the sharing experience by using the native Web Share API in the Trainer and History pages. It provides a more integrated feel on mobile devices while maintaining a robust clipboard fallback for other platforms. Localized sharing text and titles have been added to the dictionary.

---
*PR created automatically by Jules for task [14821619399791576703](https://jules.google.com/task/14821619399791576703) started by @galiprandi*