### PR TITLE
🎨 Palette: Internationalize shared routine and progress views

### DIFF
--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -304,6 +304,66 @@ export const dictionary = {
     en: "Share Progress",
     es: "Compartir progreso",
   },
+  "Set as Active?": {
+    en: "Set as Active?",
+    es: "¿Establecer como activa?",
+  },
+  "Do you want to set this routine as your active routine?": {
+    en: "Do you want to set this routine as your active routine?",
+    es: "¿Quieres establecer esta rutina como tu rutina activa?",
+  },
+  "No, Just Save": {
+    en: "No, Just Save",
+    es: "No, solo guardar",
+  },
+  "Yes, Set Active": {
+    en: "Yes, Set Active",
+    es: "Sí, establecer activa",
+  },
+  "Shared Routine": {
+    en: "Shared Routine",
+    es: "Rutina compartida",
+  },
+  "Save Routine": {
+    en: "Save Routine",
+    es: "Guardar rutina",
+  },
+  Exercises: {
+    en: "Exercises",
+    es: "Ejercicios",
+  },
+  Timing: {
+    en: "Timing",
+    es: "Tiempos",
+  },
+  Prep: {
+    en: "Prep",
+    es: "Prep",
+  },
+  Work: {
+    en: "Work",
+    es: "Trabajo",
+  },
+  Rest: {
+    en: "Rest",
+    es: "Descanso",
+  },
+  "Shared Progress": {
+    en: "Shared Progress",
+    es: "Progreso compartido",
+  },
+  "Unique Routines": {
+    en: "Unique Routines",
+    es: "Rutinas únicas",
+  },
+  "Shared by {name}": {
+    en: "Shared by {name}",
+    es: "Compartido por {name}",
+  },
+  "Loading exercises...": {
+    en: "Loading exercises...",
+    es: "Cargando ejercicios...",
+  },
 };
 
 const langs: AvailableLanguages[] = ["en", "es"];

--- a/src/components/ProgressView.astro
+++ b/src/components/ProgressView.astro
@@ -1,49 +1,51 @@
 ---
-import BasicAnalysisDashboard from './BasicAnalysisDashboard.astro'
+import BasicAnalysisDashboard from "./BasicAnalysisDashboard.astro";
 ---
 
 <div class="progress-view">
-  <h2>Shared Progress</h2>
+  <h2 data-i18n="Shared Progress">Shared Progress</h2>
   <div class="progress-user" data-user-pseudo></div>
-  
+
   <div class="progress-stats">
     <div class="stat-card">
       <div class="stat-icon">🏋️</div>
       <div class="stat-content">
         <div class="stat-value" data-stat="totalWorkouts">0</div>
-        <div class="stat-label">Total Workouts</div>
+        <div class="stat-label" data-i18n="Total Workouts">Total Workouts</div>
       </div>
     </div>
-    
+
     <div class="stat-card">
       <div class="stat-icon">⏱️</div>
       <div class="stat-content">
         <div class="stat-value" data-stat="totalDuration">0m</div>
-        <div class="stat-label">Total Time</div>
+        <div class="stat-label" data-i18n="Total Time">Total Time</div>
       </div>
     </div>
-    
+
     <div class="stat-card">
       <div class="stat-icon">📊</div>
       <div class="stat-content">
         <div class="stat-value" data-stat="uniqueRoutines">0</div>
-        <div class="stat-label">Unique Routines</div>
+        <div class="stat-label" data-i18n="Unique Routines">
+          Unique Routines
+        </div>
       </div>
     </div>
-    
+
     <div class="stat-card">
       <div class="stat-icon">🔥</div>
       <div class="stat-content">
         <div class="stat-value" data-stat="streak">0</div>
-        <div class="stat-label">Current Streak</div>
+        <div class="stat-label" data-i18n="Current Streak">Current Streak</div>
       </div>
     </div>
   </div>
-  
+
   <BasicAnalysisDashboard />
-  
+
   <div class="progress-workouts">
-    <h3>Workout History</h3>
+    <h3 data-i18n="Workout History">Workout History</h3>
     <div class="workout-list"></div>
   </div>
 </div>

--- a/src/components/RoutinePreview.astro
+++ b/src/components/RoutinePreview.astro
@@ -1,5 +1,5 @@
 ---
-import type { SharedRoutine } from '../assets/routineSharing';
+import type { SharedRoutine } from "../assets/routineSharing";
 
 interface Props {
   routine: SharedRoutine | undefined;
@@ -10,37 +10,39 @@ const { routine } = Astro.props;
 
 <div class="routine-preview">
   <div class="preview-header">
-    <h2>Shared Routine</h2>
-    <p class="routine-name">{routine?.name || 'Loading...'}</p>
+    <h2 data-i18n="Shared Routine">Shared Routine</h2>
+    <p class="routine-name">{routine?.name || "Loading..."}</p>
   </div>
 
   <div class="preview-content">
     <div class="preview-section">
-      <h3>Exercises</h3>
+      <h3 data-i18n="Exercises">Exercises</h3>
       <ul class="exercises-list">
-        {routine?.exercises.map((exercise) => (
-          <li>{exercise}</li>
-        )) || <li>Loading exercises...</li>}
+        {
+          routine?.exercises.map((exercise) => <li>{exercise}</li>) || (
+            <li data-i18n="Loading exercises...">Loading exercises...</li>
+          )
+        }
       </ul>
     </div>
 
     <div class="preview-section">
-      <h3>Timing</h3>
+      <h3 data-i18n="Timing">Timing</h3>
       <div class="timing-grid">
         <div class="timing-item">
-          <span class="label">Prep</span>
+          <span class="label" data-i18n="Prep">Prep</span>
           <span class="value">{routine?.config.prepDuration || 0}s</span>
         </div>
         <div class="timing-item">
-          <span class="label">Work</span>
+          <span class="label" data-i18n="Work">Work</span>
           <span class="value">{routine?.config.workDuration || 0}s</span>
         </div>
         <div class="timing-item">
-          <span class="label">Rest</span>
+          <span class="label" data-i18n="Rest">Rest</span>
           <span class="value">{routine?.config.restDuration || 0}s</span>
         </div>
         <div class="timing-item">
-          <span class="label">Rounds</span>
+          <span class="label" data-i18n="Rounds">Rounds</span>
           <span class="value">{routine?.config.rounds || 0}</span>
         </div>
       </div>
@@ -48,8 +50,12 @@ const { routine } = Astro.props;
   </div>
 
   <div class="preview-actions">
-    <button class="btn btn-cancel" data-action="cancel">Cancel</button>
-    <button class="btn btn-save" data-action="save">Save Routine</button>
+    <button class="btn btn-cancel" data-action="cancel" data-i18n="Cancel"
+      >Cancel</button
+    >
+    <button class="btn btn-save" data-action="save" data-i18n="Save Routine"
+      >Save Routine</button
+    >
   </div>
 </div>
 
@@ -164,7 +170,9 @@ const { routine } = Astro.props;
     font-size: 1rem;
     font-weight: 600;
     cursor: pointer;
-    transition: transform 0.15s, opacity 0.2s;
+    transition:
+      transform 0.15s,
+      opacity 0.2s;
     min-height: var(--touch-target-lg);
   }
 
@@ -193,19 +201,23 @@ const { routine } = Astro.props;
 </style>
 
 <script>
-  const preview = document.querySelector('.routine-preview');
-  const cancelButton = document.querySelector('.routine-preview .btn-cancel') as HTMLButtonElement;
-  const saveButton = document.querySelector('.routine-preview .btn-save') as HTMLButtonElement;
+  const preview = document.querySelector(".routine-preview");
+  const cancelButton = document.querySelector(
+    ".routine-preview .btn-cancel",
+  ) as HTMLButtonElement;
+  const saveButton = document.querySelector(
+    ".routine-preview .btn-save",
+  ) as HTMLButtonElement;
 
   if (cancelButton && preview) {
-    cancelButton.addEventListener('click', () => {
-      preview.dispatchEvent(new CustomEvent('cancel', { bubbles: true }));
+    cancelButton.addEventListener("click", () => {
+      preview.dispatchEvent(new CustomEvent("cancel", { bubbles: true }));
     });
   }
 
   if (saveButton && preview) {
-    saveButton.addEventListener('click', () => {
-      preview.dispatchEvent(new CustomEvent('save', { bubbles: true }));
+    saveButton.addEventListener("click", () => {
+      preview.dispatchEvent(new CustomEvent("save", { bubbles: true }));
     });
   }
 </script>

--- a/src/components/SaveConfirmation.astro
+++ b/src/components/SaveConfirmation.astro
@@ -1,19 +1,42 @@
 ---
+
 ---
 
 <div class="save-confirmation">
   <div class="confirmation-content">
     <div class="confirmation-icon">
-      <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"></path>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path
+          d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"
+        ></path>
       </svg>
     </div>
-    <h2>Set as Active?</h2>
-    <p>Do you want to set this routine as your active routine?</p>
-    
+    <h2 data-i18n="Set as Active?">Set as Active?</h2>
+    <p data-i18n="Do you want to set this routine as your active routine?">
+      Do you want to set this routine as your active routine?
+    </p>
+
     <div class="confirmation-actions">
-      <button class="btn btn-cancel" data-action="cancel">No, Just Save</button>
-      <button class="btn btn-confirm" data-action="confirm">Yes, Set Active</button>
+      <button
+        class="btn btn-cancel"
+        data-action="cancel"
+        data-i18n="No, Just Save">No, Just Save</button
+      >
+      <button
+        class="btn btn-confirm"
+        data-action="confirm"
+        data-i18n="Yes, Set Active">Yes, Set Active</button
+      >
     </div>
   </div>
 </div>
@@ -73,7 +96,9 @@
     font-size: 1rem;
     font-weight: 600;
     cursor: pointer;
-    transition: transform 0.15s, opacity 0.2s;
+    transition:
+      transform 0.15s,
+      opacity 0.2s;
     min-height: var(--touch-target-lg);
   }
 
@@ -102,19 +127,23 @@
 </style>
 
 <script>
-  const confirmation = document.querySelector('.save-confirmation');
-  const cancelButton = document.querySelector('.save-confirmation .btn-cancel') as HTMLButtonElement;
-  const confirmButton = document.querySelector('.save-confirmation .btn-confirm') as HTMLButtonElement;
+  const confirmation = document.querySelector(".save-confirmation");
+  const cancelButton = document.querySelector(
+    ".save-confirmation .btn-cancel",
+  ) as HTMLButtonElement;
+  const confirmButton = document.querySelector(
+    ".save-confirmation .btn-confirm",
+  ) as HTMLButtonElement;
 
   if (cancelButton && confirmation) {
-    cancelButton.addEventListener('click', () => {
-      confirmation.dispatchEvent(new CustomEvent('cancel', { bubbles: true }));
+    cancelButton.addEventListener("click", () => {
+      confirmation.dispatchEvent(new CustomEvent("cancel", { bubbles: true }));
     });
   }
 
   if (confirmButton && confirmation) {
-    confirmButton.addEventListener('click', () => {
-      confirmation.dispatchEvent(new CustomEvent('confirm', { bubbles: true }));
+    confirmButton.addEventListener("click", () => {
+      confirmation.dispatchEvent(new CustomEvent("confirm", { bubbles: true }));
     });
   }
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,15 @@
 ---
-import GoToTrain from '@components/GoToTrain.astro'
-import Layout from '../layouts/layout.astro'
-import InstallApp from '@components/InstallApp.astro'
-import ShareApp from '@components/ShareApp.astro'
-import GoToSettings from '@components/GoToSettings.astro'
-import GoToHistory from '@components/GoToHistory.astro'
-import GoToTrainer from '@components/GoToTrainer.astro'
-import RoutineSelector from '@components/RoutineSelector.astro'
-import RoutinePreview from '@components/RoutinePreview.astro'
-import SaveConfirmation from '@components/SaveConfirmation.astro'
-import ProgressView from '@components/ProgressView.astro'
+import GoToTrain from "@components/GoToTrain.astro";
+import Layout from "../layouts/layout.astro";
+import InstallApp from "@components/InstallApp.astro";
+import ShareApp from "@components/ShareApp.astro";
+import GoToSettings from "@components/GoToSettings.astro";
+import GoToHistory from "@components/GoToHistory.astro";
+import GoToTrainer from "@components/GoToTrainer.astro";
+import RoutineSelector from "@components/RoutineSelector.astro";
+import RoutinePreview from "@components/RoutinePreview.astro";
+import SaveConfirmation from "@components/SaveConfirmation.astro";
+import ProgressView from "@components/ProgressView.astro";
 ---
 
 <Layout>
@@ -34,7 +34,11 @@ import ProgressView from '@components/ProgressView.astro'
     <RoutinePreview routine={undefined} />
   </div>
 
-  <div id="save-confirmation-modal" class="modal-overlay" style="display: none;">
+  <div
+    id="save-confirmation-modal"
+    class="modal-overlay"
+    style="display: none;"
+  >
     <SaveConfirmation />
   </div>
 
@@ -43,133 +47,171 @@ import ProgressView from '@components/ProgressView.astro'
   </div>
 </Layout>
 
-<script is:inline>
-  import { play } from '@assets/audio'
-  import { onClick } from '@assets/domHelpers'
-  import { RoutineStorageService } from '../assets/routine'
-  import { sharedRoutineToRoutine, getSharedRoutineFromURL } from '../assets/routineSharing'
-  import { decompressProgress } from '../assets/progressSharing'
+<script>
+  import { play } from "@assets/audio";
+  import { onClick } from "@assets/domHelpers";
+  import { RoutineStorageService } from "../assets/routine";
+  import {
+    sharedRoutineToRoutine,
+    getSharedRoutineFromURL,
+  } from "../assets/routineSharing";
+  import {
+    decompressProgress,
+    type SharedProgress,
+  } from "../assets/progressSharing";
+  import { t, initTranslation } from "../assets/dictionary";
+  import type { SharedRoutine } from "../assets/routineSharing";
+  import type { WorkoutLog } from "../assets/workoutLog";
 
-  let savedRoutineId = null
+  let savedRoutineId: string | null = null;
 
-  function handleSaveSharedRoutine(sharedRoutine) {
-    const routine = sharedRoutineToRoutine(sharedRoutine)
+  function handleSaveSharedRoutine(sharedRoutine: SharedRoutine) {
+    const routine = sharedRoutineToRoutine(sharedRoutine);
     RoutineStorageService.createRoutine(
       routine.name,
       routine.config,
-      routine.exercises
-    )
-    savedRoutineId = routine.id
+      routine.exercises,
+    );
+    savedRoutineId = routine.id;
 
     // Show confirmation modal
-    const sharedModal = document.getElementById('shared-routine-modal')
-    const confirmationModal = document.getElementById('save-confirmation-modal')
-    if (sharedModal) sharedModal.style.display = 'none'
-    if (confirmationModal) confirmationModal.style.display = 'flex'
+    const sharedModal = document.getElementById("shared-routine-modal");
+    const confirmationModal = document.getElementById(
+      "save-confirmation-modal",
+    );
+    if (sharedModal) sharedModal.style.display = "none";
+    if (confirmationModal) confirmationModal.style.display = "flex";
   }
 
   function handleCancelSharedRoutine() {
     // Remove the ?r= parameter from URL
-    const url = new URL(window.location.href)
-    url.searchParams.delete('r')
-    window.history.replaceState({}, '', url.toString())
+    const url = new URL(window.location.href);
+    url.searchParams.delete("r");
+    window.history.replaceState({}, "", url.toString());
 
-    const sharedModal = document.getElementById('shared-routine-modal')
-    if (sharedModal) sharedModal.style.display = 'none'
+    const sharedModal = document.getElementById("shared-routine-modal");
+    if (sharedModal) sharedModal.style.display = "none";
   }
 
   function handleConfirmSetActive() {
     if (savedRoutineId) {
-      RoutineStorageService.setActiveRoutineId(savedRoutineId)
+      RoutineStorageService.setActiveRoutineId(savedRoutineId);
     }
 
     // Remove the ?r= parameter from URL
-    const url = new URL(window.location.href)
-    url.searchParams.delete('r')
-    window.history.replaceState({}, '', url.toString())
+    const url = new URL(window.location.href);
+    url.searchParams.delete("r");
+    window.history.replaceState({}, "", url.toString());
 
-    const confirmationModal = document.getElementById('save-confirmation-modal')
-    if (confirmationModal) confirmationModal.style.display = 'none'
+    const confirmationModal = document.getElementById(
+      "save-confirmation-modal",
+    );
+    if (confirmationModal) confirmationModal.style.display = "none";
 
     // Reload to update the UI
-    window.location.reload()
+    window.location.reload();
   }
 
   function handleCancelSetActive() {
     // Remove the ?r= parameter from URL
-    const url = new URL(window.location.href)
-    url.searchParams.delete('r')
-    window.history.replaceState({}, '', url.toString())
+    const url = new URL(window.location.href);
+    url.searchParams.delete("r");
+    window.history.replaceState({}, "", url.toString());
 
-    const confirmationModal = document.getElementById('save-confirmation-modal')
-    if (confirmationModal) confirmationModal.style.display = 'none'
+    const confirmationModal = document.getElementById(
+      "save-confirmation-modal",
+    );
+    if (confirmationModal) confirmationModal.style.display = "none";
 
     // Reload to update the UI
-    window.location.reload()
+    window.location.reload();
   }
 
-  function updateRoutinePreview(routine) {
-    const previewComponent = document.querySelector('.routine-preview')
+  function updateRoutinePreview(routine: SharedRoutine) {
+    const previewComponent = document.querySelector(
+      ".routine-preview",
+    ) as HTMLElement;
     if (previewComponent && routine) {
       // Update the preview with the routine data
-      const nameElement = previewComponent.querySelector('.routine-name')
-      const exercisesList = previewComponent.querySelector('.exercises-list')
-      const timingGrid = previewComponent.querySelector('.timing-grid')
-      
-      if (nameElement) nameElement.textContent = routine.name
+      const nameElement = previewComponent.querySelector(".routine-name");
+      const exercisesList = previewComponent.querySelector(".exercises-list");
+      const timingGrid = previewComponent.querySelector(".timing-grid");
+
+      if (nameElement) nameElement.textContent = routine.name;
       if (exercisesList) {
-        exercisesList.innerHTML = routine.exercises.map((ex) => `<li>${ex}</li>`).join('')
+        exercisesList.innerHTML = routine.exercises
+          .map((ex: string) => `<li>${ex}</li>`)
+          .join("");
       }
       if (timingGrid) {
         timingGrid.innerHTML = `
           <div class="timing-item">
-            <span class="label">Prep</span>
+            <span class="label" data-i18n="Prep">${t("Prep")}</span>
             <span class="value">${routine.config.prepDuration}s</span>
           </div>
           <div class="timing-item">
-            <span class="label">Work</span>
+            <span class="label" data-i18n="Work">${t("Work")}</span>
             <span class="value">${routine.config.workDuration}s</span>
           </div>
           <div class="timing-item">
-            <span class="label">Rest</span>
+            <span class="label" data-i18n="Rest">${t("Rest")}</span>
             <span class="value">${routine.config.restDuration}s</span>
           </div>
           <div class="timing-item">
-            <span class="label">Rounds</span>
+            <span class="label" data-i18n="Rounds">${t("Rounds")}</span>
             <span class="value">${routine.config.rounds}</span>
           </div>
-        `
+        `;
       }
+      initTranslation(previewComponent);
     }
   }
 
-  function updateProgressView(progressResult) {
-    const progressModal = document.getElementById('shared-progress-modal')
-    if (!progressModal || !progressResult.progress) return
+  function updateProgressView(progressResult: {
+    success: boolean;
+    progress: SharedProgress;
+  }) {
+    const progressModal = document.getElementById(
+      "shared-progress-modal",
+    ) as HTMLElement;
+    if (!progressModal || !progressResult.progress) return;
 
-    const progress = progressResult.progress
+    const progress = progressResult.progress;
 
     // Update user pseudo
-    const userElement = document.querySelector('[data-user-pseudo]')
+    const userElement = document.querySelector("[data-user-pseudo]");
     if (userElement) {
-      userElement.textContent = progress.userPseudo ? `Shared by ${progress.userPseudo}` : 'Shared Progress'
+      userElement.textContent = progress.userPseudo
+        ? t("Shared by {name}").replace("{name}", progress.userPseudo)
+        : t("Shared Progress");
     }
 
     // Update stats
-    const totalWorkoutsEl = document.querySelector('[data-stat="totalWorkouts"]')
-    const totalDurationEl = document.querySelector('[data-stat="totalDuration"]')
-    const uniqueRoutinesEl = document.querySelector('[data-stat="uniqueRoutines"]')
-    const streakEl = document.querySelector('[data-stat="streak"]')
-    
-    if (totalWorkoutsEl) totalWorkoutsEl.textContent = progress.summary.totalWorkouts.toString()
-    if (totalDurationEl) totalDurationEl.textContent = `${Math.floor(progress.summary.totalDuration / 60)}m`
-    if (uniqueRoutinesEl) uniqueRoutinesEl.textContent = progress.summary.uniqueRoutines.toString()
-    if (streakEl) streakEl.textContent = progress.summary.streak.toString()
+    const totalWorkoutsEl = document.querySelector(
+      '[data-stat="totalWorkouts"]',
+    );
+    const totalDurationEl = document.querySelector(
+      '[data-stat="totalDuration"]',
+    );
+    const uniqueRoutinesEl = document.querySelector(
+      '[data-stat="uniqueRoutines"]',
+    );
+    const streakEl = document.querySelector('[data-stat="streak"]');
+
+    if (totalWorkoutsEl)
+      totalWorkoutsEl.textContent = progress.summary.totalWorkouts.toString();
+    if (totalDurationEl)
+      totalDurationEl.textContent = `${Math.floor(progress.summary.totalDuration / 60)}m`;
+    if (uniqueRoutinesEl)
+      uniqueRoutinesEl.textContent = progress.summary.uniqueRoutines.toString();
+    if (streakEl) streakEl.textContent = progress.summary.streak.toString();
 
     // Update workout list
-    const workoutList = document.querySelector('.workout-list')
+    const workoutList = document.querySelector(".workout-list");
     if (workoutList) {
-      workoutList.innerHTML = progress.workoutLogs.map((log) => `
+      workoutList.innerHTML = progress.workoutLogs
+        .map(
+          (log: WorkoutLog) => `
         <div class="workout-item">
           <div class="workout-date">
             ${new Date(log.date).toLocaleDateString()}
@@ -181,65 +223,79 @@ import ProgressView from '@components/ProgressView.astro'
             ${Math.floor(log.duration / 60)}m ${log.duration % 60}s
           </div>
         </div>
-      `).join('')
+      `,
+        )
+        .join("");
     }
 
-    progressModal.style.display = 'flex'
+    initTranslation(progressModal);
+    progressModal.style.display = "flex";
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    onClick('#btn-routine-config', async () => {
-      await play('tap', true)
-      window.location.href = '/tabata/settings'
-    })
+  document.addEventListener("DOMContentLoaded", () => {
+    onClick("#btn-routine-config", async () => {
+      await play("tap", true);
+      window.location.href = "/tabata/settings";
+    });
 
     // Check for shared routine in URL
-    const sharedRoutineData = getSharedRoutineFromURL()
-    const sharedModal = document.getElementById('shared-routine-modal')
-    
-    if (sharedRoutineData && sharedRoutineData.success && sharedRoutineData.routine && sharedModal) {
-      updateRoutinePreview(sharedRoutineData.routine)
-      sharedModal.style.display = 'flex'
-      
+    const sharedRoutineData = getSharedRoutineFromURL();
+    const sharedModal = document.getElementById("shared-routine-modal");
+
+    if (
+      sharedRoutineData &&
+      sharedRoutineData.success &&
+      sharedRoutineData.routine &&
+      sharedModal
+    ) {
+      updateRoutinePreview(sharedRoutineData.routine);
+      sharedModal.style.display = "flex";
+
       // Listen for custom events from RoutinePreview
-      sharedModal.addEventListener('save', () => {
-        handleSaveSharedRoutine(sharedRoutineData.routine)
-      })
-      sharedModal.addEventListener('cancel', () => {
-        handleCancelSharedRoutine()
-      })
+      sharedModal.addEventListener("save", () => {
+        if (sharedRoutineData.routine) {
+          handleSaveSharedRoutine(sharedRoutineData.routine);
+        }
+      });
+      sharedModal.addEventListener("cancel", () => {
+        handleCancelSharedRoutine();
+      });
     }
 
     // Handle save confirmation modal
-    const confirmationModal = document.getElementById('save-confirmation-modal')
+    const confirmationModal = document.getElementById(
+      "save-confirmation-modal",
+    );
     if (confirmationModal) {
-      confirmationModal.addEventListener('confirm', () => {
-        handleConfirmSetActive()
-      })
-      confirmationModal.addEventListener('cancel', () => {
-        handleCancelSetActive()
-      })
+      confirmationModal.addEventListener("confirm", () => {
+        handleConfirmSetActive();
+      });
+      confirmationModal.addEventListener("cancel", () => {
+        handleCancelSetActive();
+      });
     }
 
     // Check for shared progress in URL
-    const progressData = decompressProgress()
+    const progressData = decompressProgress();
     if (progressData.success && progressData.progress) {
-      updateProgressView(progressData)
+      updateProgressView(
+        progressData as { success: true; progress: SharedProgress },
+      );
     }
 
     // Close progress modal handler
-    const progressModal = document.getElementById('shared-progress-modal')
+    const progressModal = document.getElementById("shared-progress-modal");
     if (progressModal) {
-      progressModal.addEventListener('click', (e) => {
+      progressModal.addEventListener("click", (e) => {
         if (e.target === progressModal) {
-          const url = new URL(window.location.href)
-          url.searchParams.delete('progress')
-          window.history.replaceState({}, '', url.toString())
-          progressModal.style.display = 'none'
+          const url = new URL(window.location.href);
+          url.searchParams.delete("progress");
+          window.history.replaceState({}, "", url.toString());
+          progressModal.style.display = "none";
         }
-      })
+      });
     }
-  })
+  });
 </script>
 
 <style>


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Internationalized the "Shared Routine", "Save Confirmation", and "Shared Progress" views on the home page. Added support for English and Spanish for all labels, titles, and confirmation messages in these views.

### 🎯 Why: The user problem it solves
Previously, these views had hardcoded English strings, making them less accessible and pleasant for Spanish-speaking users. Additionally, the main page script used module imports while being marked as `is:inline`, which is technically incorrect and can cause issues; refactoring this allowed for robust use of the translation utility.

### 📸 Before/After: Screenshots if visual change
Verified with Playwright screenshots in Spanish. Labels like "Shared Routine" now appear as "Rutina compartida", "Save Routine" as "Guardar rutina", etc.

### ♿ Accessibility: Any a11y improvements made
- Full localization support for shared views, improving accessibility for Spanish speakers.
- Standardized use of `data-i18n` attributes for consistent screen reader support across languages.
- Fixed script bundling to ensure reliable execution across different environments.

---
*PR created automatically by Jules for task [3671918848793388509](https://jules.google.com/task/3671918848793388509) started by @galiprandi*