### PR TITLE
🎨 Palette: Internationalize workout start page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,7 @@
 
 **Learning:** Implementing the native Web Share API (`navigator.share`) significantly improves the sharing experience on mobile devices, making it feel like a first-class app interaction. A robust fallback to clipboard copying ensures functionality on all platforms.
 **Action:** Use native sharing when possible, providing translatable titles and text, and always include a clipboard fallback with user feedback (e.g., localized alerts).
+
+## 2024-07-11 - [Dictionary Key Consistency and Reuse]
+**Learning:** Standardizing dictionary keys and reusing existing ones (e.g., using "Work" instead of "Working") ensures UI consistency and reduces technical debt. Inconsistent casing or redundant keys (like "Pause" vs "Pausar") lead to maintenance overhead.
+**Action:** Always audit 'src/assets/dictionary.ts' for existing concepts before adding new keys, and strictly follow the project's casing conventions (PascalCase for UI labels).

--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -81,6 +81,10 @@ export const dictionary = {
     en: "Tap image to share with your friends!",
     es: "¡Toca la imagen para compartirla con tus amigos!",
   },
+  Time: {
+    en: "Time",
+    es: "Tiempo",
+  },
   Train: {
     en: "Train",
     es: "Entrenar",
@@ -205,6 +209,22 @@ export const dictionary = {
     en: "Select a routine from the list or create a new one to begin.",
     es: "Selecciona una rutina de la lista o crea una nueva para comenzar.",
   },
+  Pause: {
+    en: "Pause",
+    es: "Pausa",
+  },
+  Paused: {
+    en: "Paused",
+    es: "Pausado",
+  },
+  Resume: {
+    en: "Resume",
+    es: "Reanudar",
+  },
+  Exit: {
+    en: "Exit",
+    es: "Salir",
+  },
   "Turn audio on": {
     en: "Turn audio on",
     es: "Activar audio",
@@ -222,6 +242,10 @@ export const dictionary = {
   "Search routine or exercise...": {
     en: "Search routine or exercise...",
     es: "Buscar rutina o ejercicio...",
+  },
+  "Next:": {
+    en: "Next:",
+    es: "Próximo:",
   },
   "Share routine": { en: "Share routine", es: "Compartir rutina" },
   "Link copied to clipboard": {
@@ -347,6 +371,10 @@ export const dictionary = {
   Prep: {
     en: "Prep",
     es: "Prep",
+  },
+  Preparation: {
+    en: "Preparation",
+    es: "Preparación",
   },
   Work: {
     en: "Work",

--- a/src/pages/start.astro
+++ b/src/pages/start.astro
@@ -18,7 +18,7 @@ import GoToHome from "@components/GoToHome.astro";
 
     <!-- Exercise name - giant, centered -->
     <div id="exercise-display" class="exercise-display speech">
-      <span id="exercise-name">Preparation</span>
+      <span id="exercise-name" data-i18n="Preparation Time">Preparation Time</span>
     </div>
 
     <!-- Timer - giant countdown -->
@@ -33,12 +33,17 @@ import GoToHome from "@components/GoToHome.astro";
 
     <!-- Next exercise preview -->
     <div id="next-exercise-preview" class="next-exercise-preview">
-      <span class="next-label">Próximo:</span>
+      <span class="next-label" data-i18n="Next:">Next:</span>
       <span id="next-exercise-name">-</span>
     </div>
 
     <!-- Pause button (visible but whole screen is tappable) -->
-    <button id="btn-pause" class="btn-pause" aria-label="Pausar">
+    <button
+      id="btn-pause"
+      class="btn-pause"
+      aria-label="Pause"
+      data-i18n-aria-label="Pause"
+    >
       <Pause />
     </button>
   </div>
@@ -46,31 +51,31 @@ import GoToHome from "@components/GoToHome.astro";
   <!-- Start modal - dismissible overlay, not blocking dialog -->
   <div id="start-overlay" class="start-overlay">
     <div class="start-card">
-      <h2 class="start-title">Rutina</h2>
+      <h2 class="start-title" data-i18n="Routine">Routine</h2>
 
       <div class="routine-info">
         <div class="info-item">
           <span class="info-value" id="total-exercises">-</span>
-          <span class="info-label">ejercicios</span>
+          <span class="info-label" data-i18n="Exercises">Exercises</span>
         </div>
         <div class="info-item">
           <span class="info-value" id="total-rounds">-</span>
-          <span class="info-label">rondas</span>
+          <span class="info-label" data-i18n="Rounds">Rounds</span>
         </div>
         <div class="info-item">
           <span class="info-value" id="total-time">-</span>
-          <span class="info-label">tiempo</span>
+          <span class="info-label" data-i18n="Time">Time</span>
         </div>
       </div>
 
       <div class="start-actions">
         <button id="btn-restart" class="btn-secondary">
           <Play />
-          <span>Reiniciar</span>
+          <span data-i18n="Restart">Restart</span>
         </button>
         <button id="btn-continue" class="btn-primary">
           <Continue />
-          <span>Continuar</span>
+          <span data-i18n="Continue">Continue</span>
         </button>
       </div>
 
@@ -84,18 +89,18 @@ import GoToHome from "@components/GoToHome.astro";
   <!-- Pause overlay -->
   <div id="pause-overlay" class="pause-overlay" style="display: none;">
     <div class="pause-card">
-      <h2 class="pause-title">Pausado</h2>
+      <h2 class="pause-title" data-i18n="Paused">Paused</h2>
       <div class="pause-actions">
         <button id="btn-resume" class="btn-primary">
           <Continue />
-          <span>Reanudar</span>
+          <span data-i18n="Resume">Resume</span>
         </button>
         <button id="btn-restart-pause" class="btn-secondary">
           <Play />
-          <span>Reiniciar</span>
+          <span data-i18n="Restart">Restart</span>
         </button>
         <button id="btn-exit" class="btn-exit">
-          <span>Salir</span>
+          <span data-i18n="Exit">Exit</span>
         </button>
       </div>
     </div>
@@ -223,9 +228,9 @@ import GoToHome from "@components/GoToHome.astro";
     if (!indicator) return;
 
     const labels: Record<string, string> = {
-      prep: "Preparación",
-      workout: "Trabajo",
-      rest: "Descanso",
+      prep: t("Preparation Time"),
+      workout: t("Work"),
+      rest: t("Rest"),
     };
     indicator.textContent = labels[phase] || phase;
     indicator.className = `phase-indicator phase-${phase}`;


### PR DESCRIPTION
This PR internationalizes the workout start page (`/start`), which previously contained hardcoded Spanish strings. 

### 🎨 What: 
- Replaced hardcoded Spanish text in `src/pages/start.astro` with localized strings using the project's i18n system.
- Refined the dictionary in `src/assets/dictionary.ts` by adding missing keys and reusing existing ones for better consistency.
- Updated dynamic phase indicators and button labels to be fully translatable.

### 🎯 Why: 
- Improves accessibility and consistency for non-Spanish speakers.
- Standardizes UI terminology across the application.
- Enhances the overall UX by making the interface more intuitive and professional in all supported languages.

### ♿ Accessibility:
- Added localized `aria-label` to the main pause button.
- Ensured all phase indicators provide clear, localized context to screen readers.

### ✅ Verification:
- Verified with Playwright screenshots in both English and Spanish locales.
- All 175 tests passed.
- Production build succeeded.
- Cleaned up local logs before submission.

---
*PR created automatically by Jules for task [5520946122480619982](https://jules.google.com/task/5520946122480619982) started by @galiprandi*