### PR TITLE
🎨 Palette: Trainer UX and Accessibility Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,6 +28,16 @@
 **Learning:** To ensure keyboard accessibility in help components, focus must be programmatically shifted to the close button when a dialog opens and returned to the trigger button when it closes.
 **Action:** When implementing native `<dialog>` elements, use `dialog.showModal()`, focus the close button immediately, and use a `once: true` listener on the 'close' event to restore focus.
 
+## 2025-10-10 - [Clipboard Feedback State Safety]
+
+**Learning:** When using temporary visual feedback (like replacing a button's icon with a checkmark "✓" on click), subsequent clicks during the timeout can capture the feedback state as the "original" state, causing the button to get stuck.
+**Action:** Always check if the feedback state is already active (e.g., `btn.innerHTML !== "✓"`) before initiating the feedback cycle.
+
+## 2025-10-10 - [SearchBar Keyboard UX]
+
+**Learning:** Supporting the 'Escape' key to clear search inputs is a standard expectation. It should not only clear the UI but also reset the search state (e.g., dispatching a 'search' event with an empty query).
+**Action:** Add a `keydown` listener for 'Escape' in search components to improve keyboard efficiency.
+
 ## 2025-08-15 - [Native Sharing UX]
 
 **Learning:** Implementing the native Web Share API (`navigator.share`) significantly improves the sharing experience on mobile devices, making it feel like a first-class app interaction. A robust fallback to clipboard copying ensures functionality on all platforms.

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -145,6 +145,17 @@
       }, 300);
     });
 
+    searchInput.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && searchInput.value) {
+        searchInput.value = "";
+        updateClearButtonVisibility();
+        const searchEvent = new CustomEvent("search", {
+          detail: { query: "" },
+        });
+        document.dispatchEvent(searchEvent);
+      }
+    });
+
     clearButton.addEventListener("click", async () => {
       await play("tap", true);
       searchInput.value = "";

--- a/src/pages/trainer.astro
+++ b/src/pages/trainer.astro
@@ -572,29 +572,44 @@ import SearchBar from "@components/SearchBar.astro";
             <span class="exercise-text">${escapeHtml(exercise)}</span>
           </div>
           <div class="exercise-actions">
-            <button type="button" class="btn-move-up" ${isFirst ? "disabled" : ""} data-i18n-title="Move exercise up">
+            <button type="button" class="btn-move-up" ${isFirst ? "disabled" : ""}
+              data-i18n-title="Move exercise up"
+              data-i18n-aria-label="Move exercise up"
+              data-tooltip="Move exercise up">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="18 15 12 9 6 15"></polyline>
               </svg>
             </button>
-            <button type="button" class="btn-move-down" ${isLast ? "disabled" : ""} data-i18n-title="Move exercise down">
+            <button type="button" class="btn-move-down" ${isLast ? "disabled" : ""}
+              data-i18n-title="Move exercise down"
+              data-i18n-aria-label="Move exercise down"
+              data-tooltip="Move exercise down">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="6 9 12 15 18 9"></polyline>
               </svg>
             </button>
-            <button type="button" class="btn-duplicate-exercise" data-i18n-title="Duplicate exercise">
+            <button type="button" class="btn-duplicate-exercise"
+              data-i18n-title="Duplicate exercise"
+              data-i18n-aria-label="Duplicate exercise"
+              data-tooltip="Duplicate exercise">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
               </svg>
             </button>
-            <button type="button" class="btn-edit-exercise" data-i18n-title="Edit exercise">
+            <button type="button" class="btn-edit-exercise"
+              data-i18n-title="Edit exercise"
+              data-i18n-aria-label="Edit exercise"
+              data-tooltip="Edit exercise">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
                 <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
               </svg>
             </button>
-            <button type="button" class="delete-exercise" data-i18n-title="Delete exercise">
+            <button type="button" class="delete-exercise"
+              data-i18n-title="Delete exercise"
+              data-i18n-aria-label="Delete exercise"
+              data-tooltip="Delete exercise">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="3 6 5 6 21"></polyline>
                 <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
@@ -809,12 +824,26 @@ import SearchBar from "@components/SearchBar.astro";
         } catch (err) {
           if ((err as Error).name !== "AbortError") {
             navigator.clipboard.writeText(result.url);
-            alert(t("Link copied to clipboard"));
+            const btn = document.getElementById("editor-btn-share");
+            if (btn && btn.innerHTML !== "✓") {
+              const originalHtml = btn.innerHTML;
+              btn.innerHTML = "✓";
+              setTimeout(() => {
+                btn.innerHTML = originalHtml;
+              }, 2000);
+            }
           }
         }
       } else {
         navigator.clipboard.writeText(result.url);
-        alert(t("Link copied to clipboard"));
+        const btn = document.getElementById("editor-btn-share");
+        if (btn && btn.innerHTML !== "✓") {
+          const originalHtml = btn.innerHTML;
+          btn.innerHTML = "✓";
+          setTimeout(() => {
+            btn.innerHTML = originalHtml;
+          }, 2000);
+        }
       }
     } else {
       alert(t("Failed to generate link"));


### PR DESCRIPTION
I have implemented several micro-UX and accessibility improvements to the Trainer page and the shared SearchBar component.

### Changes:
- **SearchBar UX**: Added support for the `Escape` key. Users can now press `Escape` while focused on the search input to quickly clear their query and reset the results.
- **Trainer Accessibility**: Added `data-i18n-aria-label` and `data-tooltip` to all exercise action buttons (Move Up/Down, Duplicate, Edit, Delete) in the Trainer editor. This ensures screen reader users have proper context and desktop users get helpful hover information.
- **Sharing Feedback**: Replaced the disruptive `alert()` in the Trainer's share functionality with a temporary checkmark (`✓`) on the share button itself. This matches the pattern used elsewhere in the app for a more seamless feel.
- **Robustness**: Fixed a race condition in the sharing feedback logic that could cause the button to get stuck showing a checkmark if clicked repeatedly.

Verified with Playwright and all repository tests passed.

---
*PR created automatically by Jules for task [1526286891968946431](https://jules.google.com/task/1526286891968946431) started by @galiprandi*