### PR TITLE
🎨 Palette: Keyboard accessibility and focus management for Workout Timer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -51,3 +51,7 @@
 ## 2024-07-11 - [Dictionary Key Consistency and Reuse]
 **Learning:** Standardizing dictionary keys and reusing existing ones (e.g., using "Work" instead of "Working") ensures UI consistency and reduces technical debt. Inconsistent casing or redundant keys (like "Pause" vs "Pausar") lead to maintenance overhead.
 **Action:** Always audit 'src/assets/dictionary.ts' for existing concepts before adding new keys, and strictly follow the project's casing conventions (PascalCase for UI labels).
+
+## 2025-07-14 - [Reliable UI Visibility Checks]
+**Learning:** Checking `element.style.display` in scripts only works for inline styles. For elements hidden via CSS classes (common in this app's Astro/Pico CSS setup), it returns an empty string, leading to incorrect logic states.
+**Action:** Use `window.getComputedStyle(el).display !== "none"` for reliable visibility checks when implementing keyboard shortcuts or conditional logic.

--- a/src/pages/start.astro
+++ b/src/pages/start.astro
@@ -124,6 +124,10 @@ import GoToHome from "@components/GoToHome.astro";
     updateRoutineInfo(config);
     renderRoundDots(config.rounds, 0);
 
+    // Initial focus on continue button
+    const btnContinue = document.getElementById("btn-continue") as HTMLButtonElement | null;
+    btnContinue?.focus();
+
     onClick("#btn-pause", () => {
       if (isWorkoutRunning) {
         pauseWorkout();
@@ -156,6 +160,42 @@ import GoToHome from "@components/GoToHome.astro";
       const target = e.target as HTMLElement;
       if (target.closest("button")) return;
       pauseWorkout();
+    });
+
+    // Keyboard controls
+    document.addEventListener("keydown", (e) => {
+      const startOverlay = document.getElementById("start-overlay");
+      const pauseOverlay = document.getElementById("pause-overlay");
+
+      const isStartVisible = startOverlay && window.getComputedStyle(startOverlay).display !== "none";
+      const isPauseVisible = pauseOverlay && window.getComputedStyle(pauseOverlay).display !== "none";
+      const isButtonFocused = e.target instanceof HTMLButtonElement;
+
+      if (e.code === "Space") {
+        if (isButtonFocused) return;
+        e.preventDefault();
+        if (isStartVisible) {
+          startWorkout();
+        } else if (isPauseVisible) {
+          resumeWorkout();
+        } else if (isWorkoutRunning) {
+          pauseWorkout();
+        }
+      } else if (e.key === "Enter") {
+        if (isButtonFocused) return;
+        if (isStartVisible) {
+          e.preventDefault();
+          startWorkout();
+        }
+      } else if (e.key === "Escape") {
+        if (isPauseVisible) {
+          resumeWorkout();
+        } else if (isWorkoutRunning) {
+          pauseWorkout();
+        } else if (isStartVisible) {
+          window.location.href = "/tabata";
+        }
+      }
     });
 
     // Swipe gestures
@@ -271,17 +311,29 @@ import GoToHome from "@components/GoToHome.astro";
 
   function showPauseOverlay() {
     const overlay = document.getElementById("pause-overlay");
-    if (overlay) overlay.style.display = "flex";
+    if (overlay) {
+      overlay.style.display = "flex";
+      const btnResume = document.getElementById("btn-resume") as HTMLButtonElement | null;
+      btnResume?.focus();
+    }
   }
 
   function hidePauseOverlay() {
     const overlay = document.getElementById("pause-overlay");
-    if (overlay) overlay.style.display = "none";
+    if (overlay) {
+      overlay.style.display = "none";
+      const btnPause = document.getElementById("btn-pause") as HTMLButtonElement | null;
+      btnPause?.focus();
+    }
   }
 
   function hideStartOverlay() {
     const overlay = document.getElementById("start-overlay");
-    if (overlay) overlay.style.display = "none";
+    if (overlay) {
+      overlay.style.display = "none";
+      const btnPause = document.getElementById("btn-pause") as HTMLButtonElement | null;
+      btnPause?.focus();
+    }
   }
 
   async function startWorkout() {


### PR DESCRIPTION
This PR adds keyboard accessibility and focus management to the Workout Timer, making it more intuitive and accessible for desktop users.

Key improvements:
- **Keyboard Shortcuts**: Users can now use `Space` to start/pause/resume, `Enter` to start, and `Escape` to pause or return home.
- **Focus Management**: The "Continue" button is focused on page load, and the "Resume" button is focused when the workout is paused, allowing immediate keyboard interaction.
- **Robust Logic**: Visibility checks now use `getComputedStyle` to correctly detect overlay states even when set via CSS classes.

These changes strictly follow the project's UX guidelines and maintain high accessibility standards.

---
*PR created automatically by Jules for task [15643934611714545204](https://jules.google.com/task/15643934611714545204) started by @galiprandi*