### PR TITLE
🎨 Palette: Localize end screen and improve history navigation

### DIFF
--- a/src/assets/dictionary.ts
+++ b/src/assets/dictionary.ts
@@ -364,6 +364,10 @@ export const dictionary = {
     en: "Save Routine",
     es: "Guardar rutina",
   },
+  Duration: {
+    en: "Duration",
+    es: "Duración",
+  },
   Exercises: {
     en: "Exercises",
     es: "Ejercicios",
@@ -491,6 +495,10 @@ export const dictionary = {
   "Average Duration": {
     en: "Average Duration",
     es: "Duración promedio",
+  },
+  more: {
+    en: "more",
+    es: "más",
   },
   "Routine Variety": {
     en: "Routine Variety",

--- a/src/components/WorkoutHistory.astro
+++ b/src/components/WorkoutHistory.astro
@@ -51,7 +51,7 @@ import TrashIcon from "./TrashIcon.astro";
           <div class="history-routine">${log.routineSnapshot.name}</div>
           <div class="history-exercises">
             ${log.routineSnapshot.exercises.slice(0, 3).join(", ")}
-            ${log.routineSnapshot.exercises.length > 3 ? ` +${log.routineSnapshot.exercises.length - 3} more` : ""}
+            ${log.routineSnapshot.exercises.length > 3 ? ` +${log.routineSnapshot.exercises.length - 3} ${t("more")}` : ""}
           </div>
         </div>
         <div class="history-duration">

--- a/src/pages/end.astro
+++ b/src/pages/end.astro
@@ -2,36 +2,46 @@
 import Layout from '@app/layouts/layout.astro'
 import Play from '@icons/Play.icon.astro'
 import GoToHome from '@components/GoToHome.astro'
+import GoToHistory from '@components/GoToHistory.astro'
 ---
 
 <Layout>
   <section class="end-screen">
     <div class="celebration">
       <div class="emoji">🎉</div>
-      <h1>¡Felicitaciones!</h1>
-      <p class="subtitle">Rutina completada</p>
+      <h1 data-i18n="Congrats">¡Felicitaciones!</h1>
+      <p class="subtitle" data-i18n="Routine completed!">Rutina completada</p>
     </div>
 
     <div class="stats-grid">
       <div class="stat-card">
         <span class="stat-value" id="stat-duration">-</span>
-        <span class="stat-label">Duración</span>
+        <span class="stat-label" data-i18n="Duration">Duración</span>
       </div>
       <div class="stat-card">
         <span class="stat-value" id="stat-rounds">-</span>
-        <span class="stat-label">Rondas</span>
+        <span class="stat-label" data-i18n="Rounds">Rondas</span>
       </div>
       <div class="stat-card">
         <span class="stat-value" id="stat-exercises">-</span>
-        <span class="stat-label">Ejercicios</span>
+        <span class="stat-label" data-i18n="Exercises">Ejercicios</span>
       </div>
     </div>
 
     <div class="end-actions">
-      <button id="startAgain" class="btn-primary">
+      <button
+        id="startAgain"
+        class="btn-primary"
+        title="Start Again"
+        aria-label="Start Again"
+        data-i18n-title="Start Again"
+        data-i18n-aria-label="Start Again"
+        data-tooltip="Start Again"
+      >
         <Play />
-        <span>Otra vez</span>
+        <span data-i18n="Start Again">Otra vez</span>
       </button>
+      <GoToHistory />
       <GoToHome />
     </div>
   </section>
@@ -42,8 +52,11 @@ import GoToHome from '@components/GoToHome.astro'
   import { RoutineStorageService } from '../assets/routine'
   import { WorkoutLogService } from '../assets/workoutLog'
   import { RoutineService } from '../assets/routine/RoutineService'
+  import { initTranslation } from '../assets/dictionary'
+  import { formatDuration } from '@assets/domHelpers'
 
   document.addEventListener('DOMContentLoaded', () => {
+    initTranslation()
     play('end')
 
     const activeRoutineId = RoutineStorageService.getActiveRoutineId()
@@ -55,20 +68,19 @@ import GoToHome from '@components/GoToHome.astro'
         const config = activeRoutine.config
         const exercises = activeRoutine.exercises
 
-        const totalDuration = (
+        const totalDuration =
           config.prepDuration +
-          (config.workDuration + config.restDuration) * config.rounds * exercises.length
-        )
+          (config.workDuration + config.restDuration) *
+            config.rounds *
+            exercises.length
 
         // Register workout in history
         WorkoutLogService.addLog(activeRoutine, totalDuration)
 
         // Display stats
-        const minutes = Math.floor(totalDuration / 60)
-        const seconds = totalDuration % 60
         const durationEl = document.getElementById('stat-duration')
         if (durationEl) {
-          durationEl.textContent = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
+          durationEl.textContent = formatDuration(totalDuration)
         }
 
         const roundsEl = document.getElementById('stat-rounds')


### PR DESCRIPTION
This PR implements several micro-UX and accessibility improvements focused on the workout completion experience and history view:

1.  **End Screen Internationalization**: Replaced hardcoded Spanish strings with localized keys (`Congrats`, `Routine completed!`, `Duration`, `Rounds`, `Exercises`, `Start Again`) in `src/pages/end.astro`.
2.  **Navigation Enhancement**: Added the `GoToHistory` component to the end screen, allowing users to jump directly to their progress statistics and history after finishing a workout.
3.  **UI Consistency**: Updated the end screen to use the shared `formatDuration` utility for time display, ensuring a consistent format across the app.
4.  **Accessibility**: Enhanced the "Start Again" button with `aria-label`, `title`, and `data-tooltip` attributes.
5.  **History Localization**: Localized the "+X more" exercise summary text in `src/components/WorkoutHistory.astro`.
6.  **Dictionary Updates**: Added missing `Duration` and `more` keys to `src/assets/dictionary.ts`.

Verified with unit tests, build checks, and visual inspection via Playwright screenshots in both English and Spanish locales.

---
*PR created automatically by Jules for task [17170263853745885517](https://jules.google.com/task/17170263853745885517) started by @galiprandi*