### PR TITLE
🎨 Palette: Scoped Keyboard Navigation & Focus Restore for Routine Selector

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -59,3 +59,7 @@
 ## 2025-11-20 - [Empty Results Recovery Pattern]
 **Learning:** Providing a direct "Clear search" action within the "No results found" state significantly reduces friction for users who have over-filtered their lists.
 **Action:** Always include a recovery button (e.g., "Clear search" or "View all") in empty search result states to prevent dead ends.
+
+## 2025-12-05 - [Localizing Scoped Event Listeners to Prevent Global Keyboard Hijacking]
+**Learning:** Registering a keydown event listener on the global `document` for dropdown or selector menu navigation (such as ArrowUp/ArrowDown) can easily hijack keyboard navigation and prevent standard scrolling page-wide, even when other elements have focus.
+**Action:** Always register list/dropdown navigation keydown listeners directly on the specific container element (e.g., `#routine-selector`) rather than on `document`, and use `window.getComputedStyle(dropdown).display !== "none"` to determine its active state.

--- a/src/components/RoutineSelector.astro
+++ b/src/components/RoutineSelector.astro
@@ -103,10 +103,11 @@
   };
 
   const init = () => {
+    const selectorContainer = document.getElementById("routine-selector");
     const selectorButton = document.getElementById("routine-selector-button");
     const dropdown = document.getElementById("routine-dropdown");
 
-    if (!selectorButton || !dropdown) return;
+    if (!selectorContainer || !selectorButton || !dropdown) return;
 
     selectorButton.addEventListener("click", async () => {
       await play("tap", true);
@@ -123,10 +124,46 @@
       }
     });
 
-    // Keyboard navigation
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape") {
+    // Keyboard navigation scoped to the selector container to prevent global hijacking
+    selectorContainer.addEventListener("keydown", (e) => {
+      const isVisible = window.getComputedStyle(dropdown).display !== "none";
+
+      if (e.key === "Escape" && isVisible) {
         closeDropdown();
+        selectorButton.focus();
+        e.preventDefault();
+      } else if (e.key === "ArrowDown" && isVisible) {
+        // Move focus down
+        e.preventDefault();
+        const active = document.activeElement;
+        const items = Array.from(dropdown.querySelectorAll(".dropdown-item")) as HTMLElement[];
+        if (items.length === 0) return;
+        const index = items.indexOf(active as HTMLElement);
+        if (index === -1 || index === items.length - 1) {
+          items[0].focus();
+        } else {
+          items[index + 1].focus();
+        }
+      } else if (e.key === "ArrowUp" && isVisible) {
+        // Move focus up
+        e.preventDefault();
+        const active = document.activeElement;
+        const items = Array.from(dropdown.querySelectorAll(".dropdown-item")) as HTMLElement[];
+        if (items.length === 0) return;
+        const index = items.indexOf(active as HTMLElement);
+        if (index === -1 || index === 0) {
+          items[items.length - 1].focus();
+        } else {
+          items[index - 1].focus();
+        }
+      } else if (e.key === "ArrowDown" && !isVisible && document.activeElement === selectorButton) {
+        // Open dropdown on ArrowDown
+        e.preventDefault();
+        toggleDropdown();
+        setTimeout(() => {
+          const first = dropdown.querySelector(".dropdown-item") as HTMLElement | null;
+          first?.focus();
+        }, 10);
       }
     });
 


### PR DESCRIPTION
Added scoped arrow key (ArrowUp/ArrowDown) and Escape key event listener inside RoutineSelector.astro to enable fully accessible keyboard dropdown navigation without globally hijacking page scrolling.

---
*PR created automatically by Jules for task [3034413904199782866](https://jules.google.com/task/3034413904199782866) started by @galiprandi*