### PR TITLE
🎨 Palette: Hide contextual actions in empty history states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -67,3 +67,7 @@
 ## 2026-06-25 - [Cohesive Initial-Load Accessibility and Interactive ARIA States]
 **Learning:** Relying solely on localization-driven attributes (such as `data-i18n-title`) can leave interactive components inaccessible before dynamic translations load or if scripts fail. Additionally, collapsible interfaces must explicitly communicate state.
 **Action:** Always provide fallback standard `title` and `aria-label` attributes alongside `data-i18n-` translations, use `aria-hidden="true"` on inline SVGs inside buttons, and dynamically maintain `aria-expanded` attributes on togglable containers.
+
+## 2026-07-19 - [Hiding Contextual Actions on Empty States]
+**Learning:** Showing action buttons (e.g., "Clear History" or "Share Progress") when there is no content to act upon causes user confusion, potential errors, or useless notifications. Hiding or disabling these actions on empty states significantly cleans up the visual hierarchy and guides the user toward the primary call to action.
+**Action:** Always verify if list-dependent action buttons should be conditionally hidden or disabled when the underlying list or data is empty.

--- a/src/components/ShareProgressButton.astro
+++ b/src/components/ShareProgressButton.astro
@@ -68,11 +68,18 @@
       ".share-progress-btn",
     ) as NodeListOf<HTMLButtonElement>;
 
+    const logs = WorkoutLogService.getLogs();
+    if (logs.length === 0) {
+      shareButtons.forEach((button) => {
+        button.style.display = "none";
+      });
+      return;
+    }
+
     shareButtons.forEach((button) => {
       button.addEventListener("click", async () => {
         await play("tap", true);
 
-        const logs = WorkoutLogService.getLogs();
         const ranges = getDateRanges();
 
         // For now, use the first range (Last 7 days)

--- a/src/components/WorkoutHistory.astro
+++ b/src/components/WorkoutHistory.astro
@@ -36,9 +36,15 @@ import TrashIcon from "./TrashIcon.astro";
   const historyList = document.querySelector(
     ".workout-history .history-list",
   ) as HTMLElement;
+  const clearButton = document.querySelector(
+    '[data-action="clear"]',
+  ) as HTMLButtonElement;
 
   if (logs.length === 0) {
     emptyState!.style.display = "block";
+    if (clearButton) {
+      clearButton.style.display = "none";
+    }
   } else {
     historyList.innerHTML = logs
       .map(
@@ -63,11 +69,7 @@ import TrashIcon from "./TrashIcon.astro";
       .join("");
   }
 
-  const clearButton = document.querySelector(
-    '[data-action="clear"]',
-  ) as HTMLButtonElement;
-
-  if (clearButton) {
+  if (clearButton && logs.length > 0) {
     clearButton.addEventListener("click", () => {
       if (
         confirm(


### PR DESCRIPTION
Hides the "Clear History" button and "Share Progress" button on the history page when there are no logged workouts. This improves user experience by reducing clutter in unpopulated states and prevents empty/destructive actions.

---
*PR created automatically by Jules for task [2602902371336423872](https://jules.google.com/task/2602902371336423872) started by @galiprandi*